### PR TITLE
Feature / remove vidispine id loop

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
@@ -10,7 +10,7 @@ case class NearlineRecord(id:Option[Int],
                           proxyObjectId:Option[String],
                           metadataXMLObjectId:Option[String],
                           internallyArchived:Option[Boolean]=None,
-                          expectingVidispineId:Boolean=true
+                          expectingVidispineId:Boolean=true,
                          )
 
 object NearlineRecord extends ((Option[Int], String, String, Option[String], Option[Int], Option[String], Option[String], Option[Boolean], Boolean) =>

--- a/online_nearline/src/main/scala/FileCopier.scala
+++ b/online_nearline/src/main/scala/FileCopier.scala
@@ -122,6 +122,19 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
     MetadataHelper.getFileSize(mxsFile)
   }
 
+  /**
+   * Copies the given file from the filesystem to MXS.
+   * If the given file already exists in the MXS vault (i.e., there is a file with a matching MXFS_PATH _and_ checksum
+   * _and_ file size, then a Right (copy-success) is returned immediately with no copy performed.
+   * If there is a file with matching MXFS_PATH but checksum and/or size do not match, then a new version is created.
+   * If there is a failure while copying, a temporary failure is returned in a Left
+   * @param vault MXS vault to check and copy to
+   * @param fileName name of the file to be copied
+   * @param filePath filesystem path to the file to be copied (as java.nio.Path)
+   * @param objectId existing objectId of the (possibly previous) version
+   * @return a Future that completes when the operation is done, containing either a Right for success (with the MXS ID in it)
+   *         or a Left on error (with an error string in it)
+   */
   def copyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path, objectId: Option[String]): Future[Either[String, String]] = {
     objectId match {
       case Some(id) =>

--- a/online_nearline/src/main/scala/VidispineHelper.scala
+++ b/online_nearline/src/main/scala/VidispineHelper.scala
@@ -1,0 +1,35 @@
+import com.gu.multimedia.storagetier.models.nearline_archive.NearlineRecord
+import com.gu.multimedia.storagetier.vidispine.VidispineCommunicator
+import org.slf4j.LoggerFactory
+import io.circe.syntax._
+import io.circe.generic.auto._
+import scala.concurrent.ExecutionContext
+
+object VidispineHelper {
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  /**
+   * Writes the Matrixstore object ID onto the metadata of the vidispine item given by itemId
+   * @param itemId Vidispine item ID
+   * @param updatedNearlineRecord NearlineRecord indicating the objectid that needs to be set
+   * @param vsCommunicator implicitly provided VidispineCommunicator instance
+   * @param ec implicitly provided ExecutionContext
+   * @return a Future, which fails on "permanent" error, returns a Right containing the nearline record converted to Circe
+   *         JSON on success or a Left containing an error string on "temporary" error
+   */
+  def updateVidispineWithMXSId(itemId:String, updatedNearlineRecord:NearlineRecord)(implicit vsCommunicator:VidispineCommunicator, ec:ExecutionContext) = {
+    logger.info(s"Updating metadata on $itemId to set nearline object id ${updatedNearlineRecord.objectId}")
+    vsCommunicator.setGroupedMetadataValue(itemId, "Asset", "gnm_nearline_id", updatedNearlineRecord.objectId).map({
+      case None=>
+        logger.error(s"Item $itemId does not exist in vidispine! (got a 404 trying to update metadata)")
+        throw new RuntimeException(s"Item $itemId does not exist in Vidispine")
+      case Some(_)=>
+        logger.info(s"Successfully updated metadata on $itemId")
+        Right(updatedNearlineRecord.asJson)
+    }).recover({
+      case err:Throwable=>
+        logger.error(s"Could not update item $itemId in Vidispine: ${err.getMessage}", err)
+        Left(s"Could not update item $itemId in Vidispine")
+    })
+  }
+}

--- a/online_nearline/src/main/scala/VidispineMessageProcessor.scala
+++ b/online_nearline/src/main/scala/VidispineMessageProcessor.scala
@@ -174,7 +174,7 @@ class VidispineMessageProcessor()
         })
     }).recoverWith({
       case err:Throwable=>
-        logger.error(s"Can't process Vidispine message: ${err.getMessage}", err)
+        logger.error(s"Can't copy to MXS: ${err.getMessage}", err)
 
         val attemptCount = attemptCountFromMDC() match {
           case Some(count)=>count
@@ -190,7 +190,6 @@ class VidispineMessageProcessor()
           errorComponent = ErrorComponents.Internal,
           retryState = RetryStates.WillRetry)
         failureRecordDAO.writeRecord(rec).map(_=>Left(err.getMessage))
-        Future.failed(err)
     })
   }
 

--- a/online_nearline/src/main/scala/VidispineMessageProcessor.scala
+++ b/online_nearline/src/main/scala/VidispineMessageProcessor.scala
@@ -174,6 +174,8 @@ class VidispineMessageProcessor()
         })
     }).recoverWith({
       case err:Throwable=>
+        logger.error(s"Can't process Vidispine message: ${err.getMessage}", err)
+
         val attemptCount = attemptCountFromMDC() match {
           case Some(count)=>count
           case None=>
@@ -188,6 +190,7 @@ class VidispineMessageProcessor()
           errorComponent = ErrorComponents.Internal,
           retryState = RetryStates.WillRetry)
         failureRecordDAO.writeRecord(rec).map(_=>Left(err.getMessage))
+        Future.failed(err)
     })
   }
 

--- a/online_nearline/src/test/scala/OwnMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/OwnMessageProcessorSpec.scala
@@ -261,24 +261,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       result must beLeft
     }
 
-    "return a Left if the vidispine ID is not yet present" in {
-      implicit val actorSystem = mock[ActorSystem]
-      implicit val mat = mock[Materializer]
-      implicit val mxsConnectionBuilder = mock[MXSConnectionBuilderImpl]
-      implicit val vsCommunicator = mock[VidispineCommunicator]
-      vsCommunicator.setMetadataValue(any,any,any) returns Future(Some(mock[ItemResponseSimplified]))
-      implicit val nearlineRecordDAO = mock[NearlineRecordDAO]
-      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234))
-      nearlineRecordDAO.getRecord(any) returns Future(Some(fakeRecord))
-      val asLookup = mock[AssetFolderLookup]
-
-      val toTest = new OwnMessageProcessor(mxsConfig, asLookup, "own-exchange-name")
-      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234)).asJson), 2.seconds)
-
-      there was one(nearlineRecordDAO).getRecord(1234)
-      there was no(vsCommunicator).setMetadataValue(any,any,any)
-      result must beLeft
-    }
+    //"return Left if no vidispine ID present" is no longer the behaviour of the code, a Right is returned in this case as well
+    //since we now ensure that the MXS ID is written to the item following media ingest
 
     "return a failed Future if the record does not exist in the datastore" in {
       implicit val actorSystem = mock[ActorSystem]


### PR DESCRIPTION
## What does this change?

- Don't loop if a copied item has no VS ID. Instead, always update the Vidispine record with MXS ID on import.

Previously, once we have successfully copied a file we look for the VS ID in our database in order to update VS with the MXS ID.  If no VS ID exists yet, we loop on the queue until it does.

This causes two problems:
- some items never get VS IDs (for a good reason), these continue to loop until they time out and cause spurious alerts
- we currently have a situation where the queue is too full of "noise" which is blocking real work getting done.  This in turn is causing a backlog of around 500, 000 items.

## How to test

- Run it up on dev
- Add some media then ingest it through assetsweeper the usual way - sweeper then vsingester.
- Monitor the logs.  When all processes are complete VS should have the MXS ID.
- Now, do the same with a second piece of media but **disable vsingester first**
- Monitor the logs. There should be no retry loop
- Next, run vsingester to ingest the item _after_ the MXS copy has taken place
- When sweeper receives the VS imported message, it should then update the VS metadata with the MXS ID

## How can we measure success?

Queue backlog goes away
