### PR TITLE
Fix for unparsable FileDocuments

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/FileDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/FileDocument.scala
@@ -6,7 +6,11 @@ import java.net.URI
 import scala.util.{Failure, Try}
 
 case class FileItemRef(id:String)
-case class FileDocument(id:String, path:String, uri:Seq[String], state:String, size:Long, hash:Option[String], timestamp:String,refreshFlag:Int, storage:String, item:Option[FileItemRef]) {
+
+/**
+Represents a FileDocument metadata entry from Vidispine. Note that `uri` _can_ be None, e.g. in the case of state==LOST
+ */
+case class FileDocument(id:String, path:String, uri:Option[Seq[String]], state:String, size:Long, hash:Option[String], timestamp:String,refreshFlag:Int, storage:String, item:Option[FileItemRef]) {
   private val logger = LoggerFactory.getLogger(getClass)
   /**
    * tries to parse the given URI string, check if it's a file: url and if so returns the path segment
@@ -27,7 +31,7 @@ case class FileDocument(id:String, path:String, uri:Seq[String], state:String, s
    * @return the path segment or None if there is none available.
    */
   def getAbsolutePath = {
-    val results = uri.map(extractFilePathFromUri)
+    val results = uri.getOrElse(Seq()).map(extractFilePathFromUri)
     val successes = results.collect({case Right(path)=>path})
     if(successes.length==1) {
       Some(successes.head)

--- a/common/src/test/scala/com/gu/multimedia/storagetier/messages/VidispineMediaIngestedSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/messages/VidispineMediaIngestedSpec.scala
@@ -1,6 +1,8 @@
 package com.gu.multimedia.storagetier.messages
 
 import org.specs2.mutable.Specification
+import io.circe.syntax._
+import io.circe.generic.auto._
 
 class VidispineMediaIngestedSpec extends Specification {
   "VidispineMediaIngested" should {

--- a/common/src/test/scala/com/gu/multimedia/storagetier/messages/VidispineMediaIngestedSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/messages/VidispineMediaIngestedSpec.scala
@@ -1,8 +1,6 @@
 package com.gu.multimedia.storagetier.messages
 
 import org.specs2.mutable.Specification
-import io.circe.syntax._
-import io.circe.generic.auto._
 
 class VidispineMediaIngestedSpec extends Specification {
   "VidispineMediaIngested" should {

--- a/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -88,7 +88,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
     }
 
     "call out to uploadIfRequiredAndNotExists" in {
-      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Seq("file:///absolute/path/relative/path.mp4"), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
+      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockVSFile))
 

--- a/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -1484,7 +1484,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       implicit val mockCopier = mock[FileCopier]
 
-      val mockedFile = FileDocument("VX-1212","media.file",Seq("file:///some/path/to/media.file"), "CLOSED",12345L, None, "", 0, "VX-7", None)
+      val mockedFile = FileDocument("VX-1212","media.file",Some(Seq("file:///some/path/to/media.file")), "CLOSED",12345L, None, "", 0, "VX-7", None)
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockedFile))
 
       val itemShapes = Seq(
@@ -1494,7 +1494,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
           None,
           Some(SimplifiedComponent(
             "VX-1212",
-            Seq(VSShapeFile(mockedFile.id, mockedFile.path, Some(mockedFile.uri), mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
+            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
           )),
           None,
           None,
@@ -1554,7 +1554,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       implicit val mockCopier = mock[FileCopier]
 
-      val mockedFile = FileDocument("VX-1212","media.file",Seq("file:///some/path/to/media.file"), "CLOSED",12345L, None, "", 0, "VX-7", None)
+      val mockedFile = FileDocument("VX-1212","media.file",Some(Seq("file:///some/path/to/media.file")), "CLOSED",12345L, None, "", 0, "VX-7", None)
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockedFile))
 
       val itemShapes = Seq()
@@ -1607,7 +1607,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       implicit val mockCopier = mock[FileCopier]
 
-      val mockedFile = FileDocument("VX-1212","media.file",Seq("file:///some/path/to/media.file"), "CLOSED",12345L, None, "", 0, "VX-7", None)
+      val mockedFile = FileDocument("VX-1212","media.file",Some(Seq("file:///some/path/to/media.file")), "CLOSED",12345L, None, "", 0, "VX-7", None)
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockedFile))
 
       val itemShapes = Seq(
@@ -1617,7 +1617,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
           None,
           Some(SimplifiedComponent(
             "VX-1212",
-            Seq(VSShapeFile(mockedFile.id, mockedFile.path, Some(mockedFile.uri), mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
+            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
           )),
           None,
           None,
@@ -1674,7 +1674,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       implicit val mockCopier = mock[FileCopier]
 
-      val mockedFile = FileDocument("VX-1212","media.file",Seq("file:///some/path/to/media.file"), "CLOSED",12345L, None, "", 0, "VX-7", None)
+      val mockedFile = FileDocument("VX-1212","media.file",Some(Seq("file:///some/path/to/media.file")), "CLOSED",12345L, None, "", 0, "VX-7", None)
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockedFile))
 
       val itemShapes = Seq(
@@ -1684,7 +1684,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
           None,
           Some(SimplifiedComponent(
             "VX-1212",
-            Seq(VSShapeFile(mockedFile.id, mockedFile.path, Some(mockedFile.uri), mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
+            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
           )),
           None,
           None,
@@ -1729,7 +1729,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       implicit val mockCopier = mock[FileCopier]
 
-      val mockedFile = FileDocument("VX-1212","media.file",Seq("file:///some/path/to/media.file"), "CLOSED",12345L, None, "", 0, "VX-7", None)
+      val mockedFile = FileDocument("VX-1212","media.file",Some(Seq("file:///some/path/to/media.file")), "CLOSED",12345L, None, "", 0, "VX-7", None)
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockedFile))
 
       val itemShapes = Seq(

--- a/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -65,7 +65,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
     }
 
     "call out to uploadIfRequiredAndNotExists" in {
-      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Seq("file:///absolute/path/relative/path.mp4"), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
+      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockVSFile))
 
@@ -109,7 +109,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
 
   "VidispineMessageProcessor.uploadIfRequiredAndNotExists" should {
     "return NearlineRecord when file has been copied to MatrixStore, and set the Nearline ID in Vidispine" in {
-      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Seq("file:///absolute/path/relative/path.mp4"), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
+      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockVSFile))
       mockVSCommunicator.setGroupedMetadataValue(any,any,any,any) returns Future(Some(mock[ItemResponseSimplified]))
@@ -159,7 +159,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
     }
 
     "return Left when file copy to MatrixStore fail" in {
-      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Seq("file:///absolute/path/relative/path.mp4"), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
+      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockVSFile))
 
@@ -207,7 +207,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
     }
 
     "return FailureRecord when exception is thrown during file copy" in {
-      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Seq("file:///absolute/path/relative/path.mp4"), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
+      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
       mockVSCommunicator.getFileInformation(any) returns Future(Some(mockVSFile))
 


### PR DESCRIPTION
## What does this change?

If a FileDocument has status of `LOST` then the `uri` field is not present. This breaks the parser; the update ensures that no URI field is treated the same as "empty URI field list".

## How to test

Deploy and replay messages that are failing on a parser error for `"state": "LOST"` and no `uri` field

## How can we measure success?

Less DLQ'd messages
