### PR TITLE
Fix/improved copy determination

### DIFF
--- a/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImpl.scala
+++ b/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImpl.scala
@@ -99,12 +99,11 @@ class MXSConnectionBuilderImpl(hosts: Array[String], clusterId:String, accessKey
   def withVaultFuture[T](vaultId:String)(cb: Vault => Future[Either[String, T]])(implicit ec:ExecutionContext) = {
     Future.fromTry(getConnection()).flatMap(mxs=>{
       isInUse = true
-      val result = MXSConnectionBuilderImpl
+      MXSConnectionBuilderImpl
         .withVaultFuture(mxs, vaultId)(cb)
         .andThen(_=>{
           isInUse = false
         })
-      result
     })
   }
 

--- a/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImpl.scala
+++ b/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImpl.scala
@@ -99,8 +99,11 @@ class MXSConnectionBuilderImpl(hosts: Array[String], clusterId:String, accessKey
   def withVaultFuture[T](vaultId:String)(cb: Vault => Future[Either[String, T]])(implicit ec:ExecutionContext) = {
     Future.fromTry(getConnection()).flatMap(mxs=>{
       isInUse = true
-      val result = MXSConnectionBuilderImpl.withVaultFuture(mxs, vaultId)(cb)
-      isInUse = false
+      val result = MXSConnectionBuilderImpl
+        .withVaultFuture(mxs, vaultId)(cb)
+        .andThen(_=>{
+          isInUse = false
+        })
       result
     })
   }

--- a/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImpl.scala
+++ b/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImpl.scala
@@ -130,21 +130,8 @@ class MXSConnectionBuilderImpl(hosts: Array[String], clusterId:String, accessKey
 object MXSConnectionBuilderImpl {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  protected def withVault[T](mxs: MatrixStore, vaultId: String)(cb: (Vault) => Try[Either[String, T]]) = {
-    Try {
-      mxs.openVault(vaultId)
-    } match {
-      case Success(vault) =>
-        val result = cb(vault)
-        vault.dispose()
-        result
-      case Failure(err) =>
-        logger.error(s"Could not establish vault connection: ${err.getMessage}", err)
-        Success(Left(err.toString))
-    }
-  }
-
-  protected def withVaultFuture[T](mxs:MatrixStore, vaultId: String)(cb: (Vault) => Future[Either[String, T]])(implicit ec:ExecutionContext) = {
+  @deprecated("From external code, you should be going via an instance of MXSConnectionBuilderImpl not the static object")
+  def withVaultFuture[T](mxs:MatrixStore, vaultId: String)(cb: (Vault) => Future[Either[String, T]])(implicit ec:ExecutionContext) = {
     Try {
       mxs.openVault(vaultId)
     } match {

--- a/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/models/ObjectMatrixEntry.scala
+++ b/mxs-copy-components/src/main/scala/com/gu/multimedia/mxscopy/models/ObjectMatrixEntry.scala
@@ -47,7 +47,7 @@ case class ObjectMatrixEntry(oid:String, attributes:Option[MxsMetadata], fileAtt
     case (_,_,_,Some(sizeString), _)=>
       sizeString.toLongOption
     case (_,_,_,_, attrs)=>
-      Some(attrs.size)
+      attrs.map(_.size)
   }
 }
 

--- a/mxs-copy-components/src/test/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImplSpec.scala
+++ b/mxs-copy-components/src/test/scala/com/gu/multimedia/mxscopy/MXSConnectionBuilderImplSpec.scala
@@ -9,60 +9,6 @@ import scala.concurrent.{Await, Future}
 import scala.util.{Failure, Success}
 
 class MXSConnectionBuilderImplSpec extends Specification with Mockito {
-  "MXSConnectionBuilderImpl.withVault" should {
-    "call the provided function and dispose the vault afterwards" in {
-      val mockVault = mock[Vault]
-
-      val mxs = mock[MatrixStore]
-      mxs.openVault(any) returns mockVault
-
-      val checker = mock[Vault=>Unit]
-
-      MXSConnectionBuilderImpl.withVault(mxs, "some-vault") { v=>
-        checker(v)
-        Success(Right("Hooray"))
-      }
-
-      there was one(checker).apply(mockVault)
-      there was one(mockVault).dispose()
-      there was one(mxs).openVault("some-vault")
-    }
-
-    "dispose the vault if the callback fails" in {
-      val mockVault = mock[Vault]
-
-      val mxs = mock[MatrixStore]
-      mxs.openVault(any) returns mockVault
-
-      val checker = mock[Vault=>Unit]
-
-      MXSConnectionBuilderImpl.withVault(mxs, "some-vault") { v=>
-        checker(v)
-        Failure(new RuntimeException("boo"))
-      }
-
-      there was one(checker).apply(mockVault)
-      there was one(mockVault).dispose()
-      there was one(mxs).openVault("some-vault")
-    }
-
-    "return a Left instead of a Failure if the vault connection fails" in {
-      val mxs = mock[MatrixStore]
-      mxs.openVault(any) throws new RuntimeException("oh no!")
-
-      val checker = mock[Vault=>Unit]
-
-      val result = MXSConnectionBuilderImpl.withVault(mxs, "some-vault") { v=>
-        checker(v)
-        Success(Right("this should not happen"))
-      }
-
-      result must beSuccessfulTry(Left("java.lang.RuntimeException: oh no!"))
-      there was one(mxs).openVault("some-vault")
-      there was no(checker).apply(any)
-    }
-  }
-
   "MXSConnectionBuilderImpl.withVaultFuture" should {
     "call the provided function and dispose the vault afterwards" in {
       val mockVault = mock[Vault]

--- a/online_nearline/src/main/scala/AssetSweeperMessageProcessor.scala
+++ b/online_nearline/src/main/scala/AssetSweeperMessageProcessor.scala
@@ -32,9 +32,8 @@ class AssetSweeperMessageProcessor()
 
   def copyFile(vault: Vault, file: AssetSweeperNewFile, maybeNearlineRecord: Option[NearlineRecord]): Future[Either[String, Json]] = {
     val fullPath = Paths.get(file.filepath, file.filename)
-    val maybeObjectId = maybeNearlineRecord.map(rec => rec.objectId)
 
-    fileCopier.copyFileToMatrixStore(vault, file.filename, fullPath, maybeObjectId)
+    fileCopier.copyFileToMatrixStore(vault, file.filename, fullPath)
       .flatMap({
         case Right(objectId) =>
           val record = maybeNearlineRecord match {

--- a/online_nearline/src/main/scala/FileCopier.scala
+++ b/online_nearline/src/main/scala/FileCopier.scala
@@ -188,7 +188,7 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
           logger.info(s"$filePath: Object already exists with object id ${existingId}")
           Future(Right(existingId))
         case None=>
-          logger.info(s"$filePath: Out of $potentialMatches remote matches, none matched the checksum so creating new copy")
+          logger.info(s"$filePath: Out of ${potentialMatches.length} remote matches, none matched the checksum so creating new copy")
           copyUsingHelper(vault, fileName, filePath)
       }
     } yield result )

--- a/online_nearline/src/main/scala/FileCopier.scala
+++ b/online_nearline/src/main/scala/FileCopier.scala
@@ -88,7 +88,7 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
       .map(fileNameMatches=>{
         val nullSizes = fileNameMatches.map(_.maybeGetSize()).collect({case None=>None}).length
         if(nullSizes>0) {
-          throw new RuntimeException(s"Could not check for matching files of $filePath because $nullSizes / ${fileNameMatches.length} had no size")
+          throw new BailOutException(s"Could not check for matching files of $filePath because $nullSizes / ${fileNameMatches.length} had no size")
         }
 
         val sizeMatches = fileNameMatches.filter(_.maybeGetSize().contains(fileSize))
@@ -132,8 +132,8 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
    * Stops and returns the ID of the first match if it finds one, or returns None if there were no matches.
    * @param filePath local file that is being backed up
    * @param potentialFiles potential backup copies of this file
-   * @param maybeLocalChecksum stored local checksum. Leave this out when calling.
-   * @return a Future containing `true` or `false`
+   * @param maybeLocalChecksum stored local checksum; if set this is used instead of re-calculating. Leave this out when calling.
+   * @return a Future containing the OID of the first matching file if present or None otherwise
    */
   protected def verifyChecksumMatch(filePath:Path, potentialFiles:Seq[MxsObject], maybeLocalChecksum:Option[String]=None):Future[Option[String]] = potentialFiles.headOption match {
     case None=>
@@ -167,7 +167,17 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
 
   protected def openMxsObject(vault:Vault, oid:String) = Try { vault.getObject(oid) }
 
-  def copyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path, objectId: Option[String]): Future[Either[String, String]] = {
+  /**
+   * Copies the given file from the filesystem to MXS.
+   * If the given file already exists in the MXS vault (i.e., there is a file with a matching MXFS_PATH _and_ checksum
+   * _and_ file size, then a Right (copy-success) is returned immediately with no copy performed.
+   * If there is a file with matching MXFS_PATH but checksum and/or size do not match, then a new version is created.
+   * If there is a failure while copying, a temporary failure is returned in a Left
+   * @param vault Vault to copy to
+   * @param fileName file name to use on the Vault
+   * @param filePath java.nio.Path giving the filepath of the item to back up
+   * */
+  def copyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path): Future[Either[String, String]] = {
     ( for {
       fileSize <- Future.fromTry(Try { getSizeFromPath(filePath) })
       potentialMatches <- findMatchingFilesOnNearline(vault, filePath, fileSize)
@@ -204,84 +214,4 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
       })
   }
 
-  /**
-   * Copies the given file from the filesystem to MXS.
-   * If the given file already exists in the MXS vault (i.e., there is a file with a matching MXFS_PATH _and_ checksum
-   * _and_ file size, then a Right (copy-success) is returned immediately with no copy performed.
-   * If there is a file with matching MXFS_PATH but checksum and/or size do not match, then a new version is created.
-   * If there is a failure while copying, a temporary failure is returned in a Left
-   * @param vault MXS vault to check and copy to
-   * @param fileName name of the file to be copied
-   * @param filePath filesystem path to the file to be copied (as java.nio.Path)
-   * @param objectId existing objectId of the (possibly previous) version
-   * @return a Future that completes when the operation is done, containing either a Right for success (with the MXS ID in it)
-   *         or a Left on error (with an error string in it)
-   */
-//  def OLDcopyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path, objectId: Option[String]): Future[Either[String, String]] = {
-//    objectId match {
-//      case Some(id) =>
-//        Future.fromTry(Try { vault.getObject(id) })
-//          .flatMap({ mxsFile =>
-//            val localFileSize = getSizeFromPath(filePath)
-//            //get the file size first, as it's possible for our connection to be logged out by the time the checksum finishes
-//            val remoteFileSize = getSizeFromMxs(mxsFile)
-//
-//            // File exist in ObjectMatrix check size and md5
-//            val savedContext = getContextMap()  //need to save the debug context for when we go in and out of akka
-//            val checksumMatchFut = Future.sequence(Seq(
-//              getChecksumFromPath(filePath),
-//              getOMFileMd5(mxsFile)
-//            )).map(results => {
-//              if(savedContext.isDefined) setContextMap(savedContext.get)
-//              val fileChecksum      = results.head.asInstanceOf[Option[String]]
-//              val applianceChecksum = results(1).asInstanceOf[Try[String]]
-//              logger.debug(s"fileChecksum is $fileChecksum")
-//              logger.debug(s"applianceChecksum is $applianceChecksum")
-//              fileChecksum == applianceChecksum.toOption
-//            })
-//
-//            checksumMatchFut.flatMap({
-//              case true => //checksums match
-//                if(savedContext.isDefined) setContextMap(savedContext.get)
-//
-//                if (remoteFileSize == localFileSize) { //file size and checksums match, no copy required
-//                  logger.info(s"Object with object id ${id} and filepath ${filePath} already exists")
-//                  Future(Right(id))
-//                } else { //checksum matches but size does not (unlikely but possible), new copy required
-//                  logger.info(s"Object with object id ${id} and filepath $filePath exists but size does not match, copying" +
-//                    s" fresh version")
-//
-//                  copyUsingHelper(vault, fileName, filePath)
-//                }
-//              case false =>
-//                if(savedContext.isDefined) setContextMap(savedContext.get)
-//                //checksums don't match, size match undetermined, new copy required
-//                logger.info(s"Object with object id ${id} and filepath $filePath exists but checksum does not match, copying fresh " +
-//                  s"version")
-//                copyUsingHelper(vault, fileName, filePath)
-//            })
-//          }).recoverWith({
-//            case err:java.io.IOException =>
-//              if(err.getMessage.contains("does not exist (error 306)")) {
-//                copyUsingHelper(vault, fileName, filePath)
-//              } else {
-//                //the most likely cause of this is that the sdk threw because the appliance is under heavy load and
-//                //can't do the checksum at this time
-//                logger.error(s"Error validating objectmatrix checksum: ${err.getMessage}", err)
-//                Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
-//              }
-//            case err:BailOutException=>
-//              logger.error(s"A permanent error occurred: ${err.getMessage}", err)
-//              Future.failed(err)
-//            case err:Throwable =>
-//              // Error contacting ObjectMatrix, log it and retry via the queue
-//              logger.warn(s"Failed to get object from vault for checksum $filePath: ${err.getClass.getCanonicalName} ${err.getMessage} , will retry", err)
-//              Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
-//            case _ =>
-//              Future(Left(s"ObjectMatrix error"))
-//          })
-//      case None =>
-//        copyUsingHelper(vault, fileName, filePath)
-//    }
-//  }
 }

--- a/online_nearline/src/main/scala/FileCopier.scala
+++ b/online_nearline/src/main/scala/FileCopier.scala
@@ -38,6 +38,14 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
 
   protected def callFindByFilenameNew(vault:Vault, fileName:String) = MatrixStoreHelper.findByFilenameNew(vault, fileName)
 
+  /**
+   * Find a free filename in the form file-{n}.xxx or file-{n}.
+   * Note that this is deprecated as it messes with the natural way of managing versions on the matrixstore.
+   * @param vault vault to check
+   * @param fileName initial filename to check
+   * @return
+   */
+  @deprecated
   def updateFilenameIfRequired(vault:Vault, fileName:String) = callFindByFilenameNew(vault, fileName)
     .map(objects=>{
       if(objects.isEmpty) {
@@ -78,6 +86,11 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
     logger.debug(s"Looking for files matching $filePath at size $fileSize")
     callFindByFilenameNew(vault, filePath.toString)
       .map(fileNameMatches=>{
+        val nullSizes = fileNameMatches.map(_.maybeGetSize()).collect({case None=>None}).length
+        if(nullSizes>0) {
+          throw new RuntimeException(s"Could not check for matching files of $filePath because $nullSizes / ${fileNameMatches.length} had no size")
+        }
+
         val sizeMatches = fileNameMatches.filter(_.maybeGetSize().contains(fileSize))
         logger.debug(s"$filePath: ${fileNameMatches.length} files matched name and ${sizeMatches.length} matched size")
         logger.debug(fileNameMatches.map(obj=>s"${obj.pathOrFilename.getOrElse("-")}: ${obj.maybeGetSize()}").mkString("; "))
@@ -87,11 +100,7 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
 
   protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path) = {
     val fromFile = filePath.toFile
-
-    updateFilenameIfRequired(vault, filePath.toString)
-      .flatMap(nameToUse=>{
-        Copier.doCopyTo(vault, Some(nameToUse), fromFile, 2*1024*1024, "md5").map(value => Right(value._1))
-      })
+    Copier.doCopyTo(vault, Some(fileName), fromFile, 2*1024*1024, "md5").map(value => Right(value._1))
   }
 
   protected def getContextMap() = {
@@ -119,6 +128,83 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
   }
 
   /**
+   * Checks to see if any of the MXS files in the `potentialFiles` list are a checksum match for `filePath`.
+   * Stops and returns the ID of the first match if it finds one, or returns None if there were no matches.
+   * @param filePath local file that is being backed up
+   * @param potentialFiles potential backup copies of this file
+   * @param maybeLocalChecksum stored local checksum. Leave this out when calling.
+   * @return a Future containing `true` or `false`
+   */
+  protected def verifyChecksumMatch(filePath:Path, potentialFiles:Seq[MxsObject], maybeLocalChecksum:Option[String]=None):Future[Option[String]] = potentialFiles.headOption match {
+    case None=>
+      logger.info(s"$filePath: No matches found for file checksum")
+      Future(None)
+    case Some(mxsFileToCheck)=>
+      logger.info(s"$filePath: Verifying checksum for MXS file ${mxsFileToCheck.getId}")
+      val savedContext = getContextMap()  //need to save the debug context for when we go in and out of akka
+      val requiredChecksums = Seq(
+        maybeLocalChecksum.map(cs=>Future(Some(cs))).getOrElse(getChecksumFromPath(filePath)),
+        getOMFileMd5(mxsFileToCheck)
+      )
+      Future
+        .sequence(requiredChecksums)
+        .map(results => {
+          if(savedContext.isDefined) setContextMap(savedContext.get)
+          val fileChecksum      = results.head.asInstanceOf[Option[String]]
+          val applianceChecksum = results(1).asInstanceOf[Try[String]]
+          logger.info(s"$filePath: local checksum is $fileChecksum, ${mxsFileToCheck.getId} checksum is $applianceChecksum")
+          (fileChecksum == applianceChecksum.toOption, fileChecksum)
+        })
+        .flatMap({
+          case (true, _)=>
+            logger.info(s"$filePath: Got a checksum match for remote file ${mxsFileToCheck.getId}")
+            Future(Some(potentialFiles.head.getId))  //true => we got a match
+          case (false, localChecksum)=>
+            logger.info(s"$filePath: ${mxsFileToCheck.getId} did not match, trying the next entry of ${potentialFiles.tail.length}")
+            verifyChecksumMatch(filePath, potentialFiles.tail, localChecksum)
+        })
+  }
+
+  protected def openMxsObject(vault:Vault, oid:String) = Try { vault.getObject(oid) }
+
+  def copyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path, objectId: Option[String]): Future[Either[String, String]] = {
+    ( for {
+      fileSize <- Future.fromTry(Try { getSizeFromPath(filePath) })
+      potentialMatches <- findMatchingFilesOnNearline(vault, filePath, fileSize)
+      potentialMatchesFiles <- Future.sequence(potentialMatches.map(entry=>Future.fromTry(openMxsObject(vault, entry.oid))))
+      alreadyExists <- verifyChecksumMatch(filePath, potentialMatchesFiles)
+      result <- alreadyExists match {
+        case Some(existingId)=>
+          logger.info(s"$filePath: Object already exists with object id ${existingId}")
+          Future(Right(existingId))
+        case None=>
+          logger.info(s"$filePath: Out of $potentialMatches remote matches, none matched the checksum so creating new copy")
+          copyUsingHelper(vault, fileName, filePath)
+      }
+    } yield result )
+      .recoverWith({
+        case err:java.io.IOException =>
+          if(err.getMessage.contains("does not exist (error 306)")) {
+            copyUsingHelper(vault, fileName, filePath)
+          } else {
+            //the most likely cause of this is that the sdk threw because the appliance is under heavy load and
+            //can't do the checksum at this time
+            logger.error(s"Error validating objectmatrix checksum: ${err.getMessage}", err)
+            Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
+          }
+        case err:BailOutException=>
+          logger.error(s"A permanent error occurred: ${err.getMessage}", err)
+          Future.failed(err)
+        case err:Throwable =>
+          // Error contacting ObjectMatrix, log it and retry via the queue
+          logger.warn(s"Failed to get object from vault for checksum $filePath: ${err.getClass.getCanonicalName} ${err.getMessage} , will retry", err)
+          Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
+        case _ =>
+          Future(Left(s"ObjectMatrix error"))
+      })
+  }
+
+  /**
    * Copies the given file from the filesystem to MXS.
    * If the given file already exists in the MXS vault (i.e., there is a file with a matching MXFS_PATH _and_ checksum
    * _and_ file size, then a Right (copy-success) is returned immediately with no copy performed.
@@ -131,70 +217,71 @@ class FileCopier()(implicit ec:ExecutionContext, mat:Materializer) {
    * @return a Future that completes when the operation is done, containing either a Right for success (with the MXS ID in it)
    *         or a Left on error (with an error string in it)
    */
-  def copyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path, objectId: Option[String]): Future[Either[String, String]] = {
-    objectId match {
-      case Some(id) =>
-        Future.fromTry(Try { vault.getObject(id) })
-          .flatMap({ mxsFile =>
-            val localFileSize = getSizeFromPath(filePath)
-            //get the file size first, as it's possible for our connection to be logged out by the time the checksum finishes
-            val remoteFileSize = getSizeFromMxs(mxsFile)
-
-            // File exist in ObjectMatrix check size and md5
-            val savedContext = getContextMap()  //need to save the debug context for when we go in and out of akka
-            val checksumMatchFut = Future.sequence(Seq(
-              getChecksumFromPath(filePath),
-              getOMFileMd5(mxsFile)
-            )).map(results => {
-              if(savedContext.isDefined) setContextMap(savedContext.get)
-              val fileChecksum      = results.head.asInstanceOf[Option[String]]
-              val applianceChecksum = results(1).asInstanceOf[Try[String]]
-              logger.debug(s"fileChecksum is $fileChecksum")
-              logger.debug(s"applianceChecksum is $applianceChecksum")
-              fileChecksum == applianceChecksum.toOption
-            })
-
-            checksumMatchFut.flatMap({
-              case true => //checksums match
-                if(savedContext.isDefined) setContextMap(savedContext.get)
-
-                if (remoteFileSize == localFileSize) { //file size and checksums match, no copy required
-                  logger.info(s"Object with object id ${id} and filepath ${filePath} already exists")
-                  Future(Right(id))
-                } else { //checksum matches but size does not (unlikely but possible), new copy required
-                  logger.info(s"Object with object id ${id} and filepath $filePath exists but size does not match, copying" +
-                    s" fresh version")
-                  copyUsingHelper(vault, fileName, filePath)
-                }
-              case false =>
-                if(savedContext.isDefined) setContextMap(savedContext.get)
-                //checksums don't match, size match undetermined, new copy required
-                logger.info(s"Object with object id ${id} and filepath $filePath exists but checksum does not match, copying fresh " +
-                  s"version")
-                copyUsingHelper(vault, fileName, filePath)
-            })
-          }).recoverWith({
-            case err:java.io.IOException =>
-              if(err.getMessage.contains("does not exist (error 306)")) {
-                copyUsingHelper(vault, fileName, filePath)
-              } else {
-                //the most likely cause of this is that the sdk threw because the appliance is under heavy load and
-                //can't do the checksum at this time
-                logger.error(s"Error validating objectmatrix checksum: ${err.getMessage}", err)
-                Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
-              }
-            case err:BailOutException=>
-              logger.error(s"A permanent error occurred: ${err.getMessage}", err)
-              Future.failed(err)
-            case err:Throwable =>
-              // Error contacting ObjectMatrix, log it and retry via the queue
-              logger.warn(s"Failed to get object from vault for checksum $filePath: ${err.getClass.getCanonicalName} ${err.getMessage} , will retry", err)
-              Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
-            case _ =>
-              Future(Left(s"ObjectMatrix error"))
-          })
-      case None =>
-        copyUsingHelper(vault, fileName, filePath)
-    }
-  }
+//  def OLDcopyFileToMatrixStore(vault: Vault, fileName: String, filePath: Path, objectId: Option[String]): Future[Either[String, String]] = {
+//    objectId match {
+//      case Some(id) =>
+//        Future.fromTry(Try { vault.getObject(id) })
+//          .flatMap({ mxsFile =>
+//            val localFileSize = getSizeFromPath(filePath)
+//            //get the file size first, as it's possible for our connection to be logged out by the time the checksum finishes
+//            val remoteFileSize = getSizeFromMxs(mxsFile)
+//
+//            // File exist in ObjectMatrix check size and md5
+//            val savedContext = getContextMap()  //need to save the debug context for when we go in and out of akka
+//            val checksumMatchFut = Future.sequence(Seq(
+//              getChecksumFromPath(filePath),
+//              getOMFileMd5(mxsFile)
+//            )).map(results => {
+//              if(savedContext.isDefined) setContextMap(savedContext.get)
+//              val fileChecksum      = results.head.asInstanceOf[Option[String]]
+//              val applianceChecksum = results(1).asInstanceOf[Try[String]]
+//              logger.debug(s"fileChecksum is $fileChecksum")
+//              logger.debug(s"applianceChecksum is $applianceChecksum")
+//              fileChecksum == applianceChecksum.toOption
+//            })
+//
+//            checksumMatchFut.flatMap({
+//              case true => //checksums match
+//                if(savedContext.isDefined) setContextMap(savedContext.get)
+//
+//                if (remoteFileSize == localFileSize) { //file size and checksums match, no copy required
+//                  logger.info(s"Object with object id ${id} and filepath ${filePath} already exists")
+//                  Future(Right(id))
+//                } else { //checksum matches but size does not (unlikely but possible), new copy required
+//                  logger.info(s"Object with object id ${id} and filepath $filePath exists but size does not match, copying" +
+//                    s" fresh version")
+//
+//                  copyUsingHelper(vault, fileName, filePath)
+//                }
+//              case false =>
+//                if(savedContext.isDefined) setContextMap(savedContext.get)
+//                //checksums don't match, size match undetermined, new copy required
+//                logger.info(s"Object with object id ${id} and filepath $filePath exists but checksum does not match, copying fresh " +
+//                  s"version")
+//                copyUsingHelper(vault, fileName, filePath)
+//            })
+//          }).recoverWith({
+//            case err:java.io.IOException =>
+//              if(err.getMessage.contains("does not exist (error 306)")) {
+//                copyUsingHelper(vault, fileName, filePath)
+//              } else {
+//                //the most likely cause of this is that the sdk threw because the appliance is under heavy load and
+//                //can't do the checksum at this time
+//                logger.error(s"Error validating objectmatrix checksum: ${err.getMessage}", err)
+//                Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
+//              }
+//            case err:BailOutException=>
+//              logger.error(s"A permanent error occurred: ${err.getMessage}", err)
+//              Future.failed(err)
+//            case err:Throwable =>
+//              // Error contacting ObjectMatrix, log it and retry via the queue
+//              logger.warn(s"Failed to get object from vault for checksum $filePath: ${err.getClass.getCanonicalName} ${err.getMessage} , will retry", err)
+//              Future(Left(s"ObjectMatrix error: ${err.getMessage}"))
+//            case _ =>
+//              Future(Left(s"ObjectMatrix error"))
+//          })
+//      case None =>
+//        copyUsingHelper(vault, fileName, filePath)
+//    }
+//  }
 }

--- a/online_nearline/src/main/scala/VidispineMessageProcessor.scala
+++ b/online_nearline/src/main/scala/VidispineMessageProcessor.scala
@@ -139,7 +139,7 @@ class VidispineMessageProcessor()
 
       showPreviousFailure(maybeFailureRecord, absPath)
 
-      fileCopier.copyFileToMatrixStore(vault, fullPath.getFileName.toString, fullPath, maybeObjectId)
+      fileCopier.copyFileToMatrixStore(vault, fullPath.getFileName.toString, fullPath)
         .flatMap({
           case Right(objectId) =>
             val record = maybeNearlineRecord match {
@@ -341,7 +341,7 @@ class VidispineMessageProcessor()
     val proxyFileName = uploadKeyForProxy(nearlineRecord, proxyFile)
 
     val copyResult = for {
-      copyResult <- fileCopier.copyFileToMatrixStore(vault, proxyFileName, fullPath, None)
+      copyResult <- fileCopier.copyFileToMatrixStore(vault, proxyFileName, fullPath)
       metadataUpdate <- buildMetadataForProxy(vault, nearlineRecord)
       writeResult <- Future.fromTry((copyResult, metadataUpdate) match {
         case (Left(_), _)=>Success( () ) //ignore

--- a/online_nearline/src/test/scala/AssetSweeperMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/AssetSweeperMessageProcessorSpec.scala
@@ -32,7 +32,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val fileCopier = mock[FileCopier]
-      fileCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Right("some-object-id"))
+      fileCopier.copyFileToMatrixStore(any, any, any) returns Future(Right("some-object-id"))
       val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
       mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
 
@@ -86,7 +86,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val fileCopier = mock[FileCopier]
-      fileCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Right("some-object-id"))
+      fileCopier.copyFileToMatrixStore(any, any, any) returns Future(Right("some-object-id"))
 
       val mockVault = mock[Vault]
       //workaround from https://stackoverflow.com/questions/3762047/throw-checked-exceptions-from-mocks-with-mockito
@@ -125,7 +125,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val fileCopier = mock[FileCopier]
-      fileCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Right("some-object-id"))
+      fileCopier.copyFileToMatrixStore(any, any, any) returns Future(Right("some-object-id"))
 
       val mockVault = mock[Vault]
       //workaround from https://stackoverflow.com/questions/3762047/throw-checked-exceptions-from-mocks-with-mockito
@@ -143,7 +143,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       val result = Await.result(toTest.processFile(mockFile, mockVault), 3.seconds)
 
       there was one(mockCheckPreExisting).apply(mockVault, mockFile)
-      there was no(fileCopier).copyFileToMatrixStore(any,any,any,any)
+      there was no(fileCopier).copyFileToMatrixStore(any,any,any)
       result must beRight(rec.asJson)
     }
 
@@ -172,7 +172,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       implicit val fileCopier = mock[FileCopier]
 
       val mockExc = new RuntimeException("ObjectMatrix out of office right now!!")
-      fileCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Left(s"ObjectMatrix error: ${mockExc.getMessage}"))
+      fileCopier.copyFileToMatrixStore(any, any, any) returns Future(Left(s"ObjectMatrix error: ${mockExc.getMessage}"))
 
       val mockVault = mock[Vault]
       mockVault.getObject(any) throws mockExc

--- a/online_nearline/src/test/scala/FileCopierSpec.scala
+++ b/online_nearline/src/test/scala/FileCopierSpec.scala
@@ -7,11 +7,9 @@ import org.specs2.mutable.Specification
 import java.io.IOException
 import scala.concurrent.ExecutionContext.Implicits.global
 import java.nio.file.{Path, Paths}
-import java.util
-import java.util.Map
 import scala.concurrent.duration.DurationInt
 import scala.concurrent.{Await, Future}
-import scala.util.Try
+import scala.util.{Success, Try}
 
 class FileCopierSpec extends Specification with Mockito {
   "FileCopier.maybeGetIndex" should {
@@ -116,14 +114,27 @@ class FileCopierSpec extends Specification with Mockito {
       val mockCopyUsingHelper = mock[(Vault, String, Path)=> Future[Right[Nothing, String]]]
       mockCopyUsingHelper.apply(any, any, any) returns Future(Right("some-object-id"))
 
+      val mockGetSize = mock[(Path)=>Long]
+      mockGetSize.apply(any) returns 1234L
+
+      val mockFindMatchingFiles = mock[(Vault, Path, Long)=>Future[Seq[ObjectMatrixEntry]]]
+      mockFindMatchingFiles(any,any,any) returns Future(Seq())
+
       val toTest = new FileCopier() {
         override protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path): Future[Right[Nothing, String]] =
           mockCopyUsingHelper(vault, fileName, filePath)
+
+        override protected def getSizeFromPath(filePath: Path): Long = mockGetSize(filePath)
+
+        override def findMatchingFilesOnNearline(vault: Vault, filePath: Path, fileSize: Long): Future[Seq[ObjectMatrixEntry]] = mockFindMatchingFiles(vault, filePath, fileSize)
       }
 
       val result = Await.result(toTest.copyFileToMatrixStore(mockVault, "file-name.mp4", mockFilePath, None), 3.seconds)
 
-      result must beEqualTo(Right("some-object-id"))
+      there was one(mockGetSize).apply(mockFilePath)
+      there was one(mockFindMatchingFiles).apply(mockVault, mockFilePath, 1234L)
+      there was one(mockCopyUsingHelper).apply(mockVault, "file-name.mp4", mockFilePath)
+      result must beRight("some-object-id")
     }
 
     "perform an upload with an existing objectId with different file size and return objectId" in {
@@ -136,16 +147,24 @@ class FileCopierSpec extends Specification with Mockito {
 
       val mockCopyUsingHelper = mock[(Vault, String, Path)=> Future[Right[Nothing, String]]]
       mockCopyUsingHelper.apply(any, any, any) returns Future(Right("existing-object-id"))
+      val mockGetSize = mock[(Path)=>Long]
+      mockGetSize.apply(any) returns 1234L
+
+      val mockFindMatchingFiles = mock[(Vault, Path, Long)=>Future[Seq[ObjectMatrixEntry]]]
+      mockFindMatchingFiles(any,any,any) returns Future(Seq())
+
+      val mockVerifyChecksum = mock[(Path, Seq[MxsObject], Option[String])=>Future[Option[String]]]
+      mockVerifyChecksum.apply(any,any,any) returns Future(None)
 
       val toTest = new FileCopier() {
         override protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path): Future[Right[Nothing, String]] =
           mockCopyUsingHelper(vault, fileName, filePath)
 
         override protected def getContextMap() = {
-          Some(new util.HashMap[String, String]())
+          Some(new java.util.HashMap[String, String]())
         }
 
-        override protected def setContextMap(contextMap: Map[String, String]) = {
+        override protected def setContextMap(contextMap: java.util.Map[String, String]) = {
         }
 
         override protected def getOMFileMd5(mxsFile: MxsObject) = {
@@ -156,19 +175,21 @@ class FileCopierSpec extends Specification with Mockito {
           Future(Some("md5-checksum-1"))
         }
 
-        override protected def getSizeFromPath(filePath: Path) = {
-          1000L
-        }
+        override protected def getSizeFromPath(filePath: Path): Long = mockGetSize(filePath)
 
-        override protected def getSizeFromMxs(mxsFile: MxsObject) = {
-          10L
-        }
+        override def findMatchingFilesOnNearline(vault: Vault, filePath: Path, fileSize: Long): Future[Seq[ObjectMatrixEntry]] = mockFindMatchingFiles(vault, filePath, fileSize)
+
+        override protected def verifyChecksumMatch(filePath: Path, potentialFiles: Seq[MxsObject], maybeLocalChecksum: Option[String]): Future[Option[String]] = mockVerifyChecksum(filePath, potentialFiles, maybeLocalChecksum)
       }
 
       val result = Await.result(toTest.copyFileToMatrixStore(mockVault, "file-name.mp4", mockFilePath, Some("existing-object-id")),
         3.seconds)
 
-      result must beEqualTo(Right("existing-object-id"))
+      there was one(mockGetSize).apply(mockFilePath)
+      there was one(mockFindMatchingFiles).apply(mockVault, mockFilePath, 1234L)
+      there was one(mockCopyUsingHelper).apply(mockVault, "file-name.mp4", mockFilePath)
+      there was one(mockVerifyChecksum).apply(mockFilePath,Seq(),None) //the file sizes do not match so we should not have undertaken the checksum verify
+      result must beRight("existing-object-id")
     }
 
     "perform an upload with an existing objectId with different checksum and return objectId" in {
@@ -181,39 +202,56 @@ class FileCopierSpec extends Specification with Mockito {
 
       val mockCopyUsingHelper = mock[(Vault, String, Path)=> Future[Right[Nothing, String]]]
       mockCopyUsingHelper.apply(any, any, any) returns Future(Right("existing-object-id"))
+      val mockGetSize = mock[(Path)=>Long]
+      mockGetSize.apply(any) returns 1234L
+
+      val mockFindMatchingFiles = mock[(Vault, Path, Long)=>Future[Seq[ObjectMatrixEntry]]]
+      mockFindMatchingFiles(any,any,any) returns Future(Seq(
+        ObjectMatrixEntry("existing-object-id",Some(MxsMetadata(
+          Map("__mxs__length"->"1234"),
+          Map(),
+          Map(),
+          Map()
+        )), None)
+      ))
+
+      val mockExistingObject = mock[MxsObject]
+
+      val mockOpenMxsObject = mock[(Vault, String)=>Try[MxsObject]]
+      mockOpenMxsObject.apply(any, any) returns Success(mockExistingObject)
+
+      val mockVerifyChecksum = mock[(Path, Seq[MxsObject], Option[String])=>Future[Option[String]]]
+      mockVerifyChecksum.apply(any,any,any) returns Future(None)
 
       val toTest = new FileCopier() {
         override protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path): Future[Right[Nothing, String]] =
           mockCopyUsingHelper(vault, fileName, filePath)
 
         override protected def getContextMap() = {
-          Some(new util.HashMap[String, String]())
+          Some(new java.util.HashMap[String, String]())
         }
 
-        override protected def setContextMap(contextMap: Map[String, String]) = {
+        override protected def setContextMap(contextMap: java.util.Map[String, String]) = {
         }
 
-        override protected def getOMFileMd5(mxsFile: MxsObject) = {
-          Future(Try("md5-checksum-1"))
-        }
+        override def openMxsObject(vault: Vault, oid: String): Try[MxsObject] = mockOpenMxsObject(vault, oid)
 
-        override protected def getChecksumFromPath(filePath: Path): Future[Option[String]] = {
-          Future(Some("md5-checksum-2"))
-        }
+        override protected def getSizeFromPath(filePath: Path): Long = mockGetSize(filePath)
 
-        override protected def getSizeFromPath(filePath: Path) = {
-          10L
-        }
+        override def findMatchingFilesOnNearline(vault: Vault, filePath: Path, fileSize: Long): Future[Seq[ObjectMatrixEntry]] = mockFindMatchingFiles(vault, filePath, fileSize)
 
-        override protected def getSizeFromMxs(mxsFile: MxsObject) = {
-          10L
-        }
+        override protected def verifyChecksumMatch(filePath: Path, potentialFiles: Seq[MxsObject], maybeLocalChecksum: Option[String]): Future[Option[String]] = mockVerifyChecksum(filePath, potentialFiles, maybeLocalChecksum)
+
       }
 
       val result = Await.result(toTest.copyFileToMatrixStore(mockVault, "file-name.mp4", mockFilePath, Some("existing-object-id")),
         3.seconds)
 
-      result must beEqualTo(Right("existing-object-id"))
+      there was one(mockFindMatchingFiles).apply(mockVault, mockFilePath, 1234L)
+      there was one(mockOpenMxsObject).apply(mockVault, "existing-object-id")
+      there was one(mockVerifyChecksum).apply(mockFilePath, Seq(mockExistingObject), None)
+
+      result must beRight("existing-object-id")
     }
 
     "return Right with objectId if an object with same size and checksum already exist in ObjectMatrix" in {
@@ -227,15 +265,36 @@ class FileCopierSpec extends Specification with Mockito {
       val mockCopyUsingHelper = mock[(Vault, String, Path)=> Future[Right[Nothing, String]]]
       mockCopyUsingHelper.apply(any, any, any) returns Future(Right("existing-object-id"))
 
+      val mockGetSize = mock[(Path)=>Long]
+      mockGetSize.apply(any) returns 1234L
+
+      val mockFindMatchingFiles = mock[(Vault, Path, Long)=>Future[Seq[ObjectMatrixEntry]]]
+      mockFindMatchingFiles(any,any,any) returns Future(Seq(
+        ObjectMatrixEntry("existing-object-id",Some(MxsMetadata(
+          Map("__mxs__length"->"1234"),
+          Map(),
+          Map(),
+          Map()
+        )), None)
+      ))
+
+      val mockExistingObject = mock[MxsObject]
+
+      val mockOpenMxsObject = mock[(Vault, String)=>Try[MxsObject]]
+      mockOpenMxsObject.apply(any, any) returns Success(mockExistingObject)
+
+      val mockVerifyChecksum = mock[(Path, Seq[MxsObject], Option[String])=>Future[Option[String]]]
+      mockVerifyChecksum.apply(any,any,any) returns Future(Some("existing-object-id"))
+
       val toTest = new FileCopier() {
         override protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path): Future[Right[Nothing, String]] =
           mockCopyUsingHelper(vault, fileName, filePath)
 
         override protected def getContextMap() = {
-          Some(new util.HashMap[String, String]())
+          Some(new java.util.HashMap[String, String]())
         }
 
-        override protected def setContextMap(contextMap: Map[String, String]) = {
+        override protected def setContextMap(contextMap: java.util.Map[String, String]) = {
         }
 
         override protected def getOMFileMd5(mxsFile: MxsObject) = {
@@ -246,63 +305,58 @@ class FileCopierSpec extends Specification with Mockito {
           Future(Some("md5-checksum-1"))
         }
 
-        override protected def getSizeFromPath(filePath: Path) = {
-          10L
-        }
+        override def openMxsObject(vault: Vault, oid: String): Try[MxsObject] = mockOpenMxsObject(vault, oid)
 
-        override protected def getSizeFromMxs(mxsFile: MxsObject) = {
-          10L
-        }
+        override protected def getSizeFromPath(filePath: Path): Long = mockGetSize(filePath)
+
+        override def findMatchingFilesOnNearline(vault: Vault, filePath: Path, fileSize: Long): Future[Seq[ObjectMatrixEntry]] = mockFindMatchingFiles(vault, filePath, fileSize)
+
+        override protected def verifyChecksumMatch(filePath: Path, potentialFiles: Seq[MxsObject], maybeLocalChecksum: Option[String]): Future[Option[String]] = mockVerifyChecksum(filePath, potentialFiles, maybeLocalChecksum)
       }
 
       val result = Await.result(toTest.copyFileToMatrixStore(mockVault, "file-name.mp4", mockFilePath, Some("existing-object-id")),
         3.seconds)
 
-      result must beEqualTo(Right("existing-object-id"))
+      there was one(mockGetSize).apply(mockFilePath)
+      there was one(mockFindMatchingFiles).apply(mockVault, mockFilePath, 1234L)
+      there was one(mockOpenMxsObject).apply(mockVault, "existing-object-id")
+      there was one(mockVerifyChecksum).apply(mockFilePath, Seq(mockExistingObject), None)
+      there was no(mockCopyUsingHelper).apply(any,any,any)
+      result must beRight("existing-object-id")
     }
 
-    "return Right with objectId if an object with same id doesn't exist in ObjectMatrix" in {
-      implicit val mat:Materializer = mock[Materializer]
-
-      val mockVault = mock[Vault]
-      //workaround from https://stackoverflow.com/questions/3762047/throw-checked-exceptions-from-mocks-with-mockito
-      mockVault.getObject(any) answers( (x:Any)=> throw new IOException("Invalid object, it does not exist (error 306)"))
-      val mockFilePath = Paths.get("/some/path/", "file-name.mp4")
-
-      val mockCopyUsingHelper = mock[(Vault, String, Path)=> Future[Right[Nothing, String]]]
-      mockCopyUsingHelper.apply(any, any, any) returns Future(Right("existing-object-id"))
-
-      val toTest = new FileCopier() {
-        override protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path): Future[Right[Nothing, String]] =
-          mockCopyUsingHelper(vault, fileName, filePath)
-      }
-
-      val result = Await.result(toTest.copyFileToMatrixStore(mockVault, "file-name.mp4", mockFilePath, Some("existing-object-id")),
-        3.seconds)
-
-      result must beEqualTo(Right("existing-object-id"))
-    }
+    //this test was removed as it is now functionally identical to the first
 
     "return Left with error message when unknown Exception is thrown by ObjectMatrix" in {
       implicit val mat:Materializer = mock[Materializer]
 
       val mockVault = mock[Vault]
-      //workaround from https://stackoverflow.com/questions/3762047/throw-checked-exceptions-from-mocks-with-mockito
-      mockVault.getObject(any) answers( (x:Any)=> throw new RuntimeException("Some unknown exception"))
       val mockFilePath = Paths.get("/some/path/", "file-name.mp4")
 
       val mockCopyUsingHelper = mock[(Vault, String, Path)=> Future[Right[Nothing, String]]]
       mockCopyUsingHelper.apply(any, any, any) returns Future(Right("existing-object-id"))
 
+      val mockGetSize = mock[Path=>Long]
+      mockGetSize.apply(any) returns 1234
+
+      val mockFindMatchingFiles = mock[(Vault, Path, Long)=>Future[Seq[ObjectMatrixEntry]]]
+      mockFindMatchingFiles.apply(any,any,any) returns Future.failed(new RuntimeException("Some unknown exception"))
+
       val toTest = new FileCopier() {
         override protected def copyUsingHelper(vault: Vault, fileName: String, filePath: Path): Future[Right[Nothing, String]] =
           mockCopyUsingHelper(vault, fileName, filePath)
+
+        override def getSizeFromPath(filePath: Path): Long = mockGetSize(filePath)
+
+        override def findMatchingFilesOnNearline(vault: Vault, filePath: Path, fileSize: Long): Future[Seq[ObjectMatrixEntry]] = mockFindMatchingFiles(vault, filePath, fileSize)
       }
 
       val result = Await.result(toTest.copyFileToMatrixStore(mockVault, "file-name.mp4", mockFilePath, Some("existing-object-id")),
         3.seconds)
 
-      result must beEqualTo(Left("ObjectMatrix error: Some unknown exception"))
+      there was one(mockGetSize).apply(mockFilePath)
+      result must beLeft("ObjectMatrix error: Some unknown exception")
     }
   }
+
 }

--- a/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -133,7 +133,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Right("object-id"))
+      mockCopier.copyFileToMatrixStore(any, any, any) returns Future(Right("object-id"))
 
       val mockVault = mock[Vault]
       val mockObject = mock[MxsObject]
@@ -182,7 +182,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Left("Something went wrong!!"))
+      mockCopier.copyFileToMatrixStore(any, any, any) returns Future(Left("Something went wrong!!"))
 
       val mockVault = mock[Vault]
       val mockObject = mock[MxsObject]
@@ -230,7 +230,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) throws new RuntimeException("Crash during copy!!!")
+      mockCopier.copyFileToMatrixStore(any, any, any) throws new RuntimeException("Crash during copy!!!")
 
       val mockVault = mock[Vault]
       val mockObject = mock[MxsObject]
@@ -978,7 +978,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Left("Error copying file"))
+      mockCopier.copyFileToMatrixStore(any, any, any) returns Future(Left("Error copying file"))
 
       implicit val mockBuilder = mock[MXSConnectionBuilder]
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
@@ -1090,7 +1090,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Left("Error copying file"))
+      mockCopier.copyFileToMatrixStore(any, any, any) returns Future(Left("Error copying file"))
 
       implicit val mockBuilder = mock[MXSConnectionBuilder]
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
@@ -1218,7 +1218,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Left("Error copying file"))
+      mockCopier.copyFileToMatrixStore(any, any, any) returns Future(Left("Error copying file"))
 
       implicit val mockBuilder = mock[MXSConnectionBuilder]
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
@@ -1279,7 +1279,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
       implicit val mat:Materializer = mock[Materializer]
       implicit val sys:ActorSystem = mock[ActorSystem]
       implicit val mockCopier = mock[FileCopier]
-      mockCopier.copyFileToMatrixStore(any, any, any, any) returns Future(Right("VX-1234"))
+      mockCopier.copyFileToMatrixStore(any, any, any) returns Future(Right("VX-1234"))
 
       implicit val mockBuilder = mock[MXSConnectionBuilder]
       implicit val mockVSCommunicator = mock[VidispineCommunicator]


### PR DESCRIPTION
## What does this change?

Improves the decision process as to whether a new file should get copied, to fix https://codemill.atlassian.net/browse/GP-725.

Previously, if the expected file did _not_ match size or checksum with the candidate file, a backup could be made regardless of whether there was another matching version.  This lead to large loops of files getting continuously backed up.

This update performs size/checksum verification against _all_ versions present - if _any_ matching version is found then the copy is not undertaken.  Care has been taken to minimise the overall impact of this process by only evaluating checksums that are required, and only doing it once.

**Note** that the old file-1, file-2 incremental behaviour has been removed because it complicates matters significantly and is not required when writing content onto the Matrixstore. If this causes problems on restore we should look at implementing this in the restore process.

## How to test
Deploy and monitor the file `/srv/Multimedia2/Media Production/Assets/Multimedia_News/Mens_mental_health_-Modern_masculinity/bruno_rinvolucri_Mens_mental_health-_Modern_masculinity/03:09:10 September/Clip/Clip0076.MXF` and others which have had large numbers of duplicates. They should now be correctly detected as not requiring another backup

## How can we measure success?

Less errors and less pointless duplicate files

## Have we considered potential risks?
This adjusts core functionality in the backups process and therefore needs to be monitored once deployed to ensure that there are no ill-effects
