### PR TITLE
Fix/less retries

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/framework/MessageProcessingFramework.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/framework/MessageProcessingFramework.scala
@@ -419,7 +419,9 @@ object MessageProcessingFramework {
             retryExchangeName:String,
             failedExchangeName:String,
             failedQueueName:String,
-            handlers:Seq[ProcessorConfiguration])
+            handlers:Seq[ProcessorConfiguration],
+            maximumDelayTime:Int=120000,
+            maximumRetryLimit:Int=200)
            (implicit connectionFactoryProvider: ConnectionFactoryProvider, ec:ExecutionContext) = {
     val exchangeNames = handlers.map(_.exchangeName)
     if(exchangeNames.distinct.length != exchangeNames.length) { // in this case there must be duplicates
@@ -438,7 +440,9 @@ object MessageProcessingFramework {
               retryExchangeName,
               failedExchangeName,
               failedQueueName,
-              handlers)(channel, conn)
+              handlers,
+              maximumDelayTime,
+              maximumRetryLimit)(channel, conn)
           )
       }
     }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/framework/MessageProcessingFramework.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/framework/MessageProcessingFramework.scala
@@ -38,7 +38,7 @@ class MessageProcessingFramework (ingest_queue_name:String,
                                   failedQueueName:String,
                                   handlers:Seq[ProcessorConfiguration],
                                   maximumDelayTime:Int=120000,
-                                  maximumRetryLimit:Int=500)
+                                  maximumRetryLimit:Int=200)
                                  (channel:Channel, conn:Connection)(implicit ec:ExecutionContext){
   private val logger = LoggerFactory.getLogger(getClass)
   private val cs = Charset.forName("UTF-8")

--- a/online_nearline/src/main/scala/Main.scala
+++ b/online_nearline/src/main/scala/Main.scala
@@ -57,6 +57,8 @@ object Main {
     case Right(config)=>config
   }
 
+  private lazy val retryLimit = sys.env.get("RETRY_LIMIT").map(_.toInt).getOrElse(200)
+
   def main(args:Array[String]):Unit = {
     implicit lazy val nearlineRecordDAO = new NearlineRecordDAO(db)
     implicit lazy val failureRecordDAO = new FailureRecordDAO(db)
@@ -99,7 +101,8 @@ object Main {
       "storagetier-online-nearline-retry",
       "storagetier-online-nearline-fail",
       "storagetier-online-nearline-dlq",
-      config
+      config,
+      maximumRetryLimit = retryLimit
     ) match {
       case Left(err) =>
         logger.error(s"Could not initiate message processing framework: $err")

--- a/scripts/vidispine-no-nearlineid/requeue-missing-nearlineid.py
+++ b/scripts/vidispine-no-nearlineid/requeue-missing-nearlineid.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from gnmvidispine.vs_search import *
+from gnmvidispine.vs_shape import VSShape
 from argparse import ArgumentParser
 import pika
 import logging
@@ -92,6 +93,20 @@ class RMQCredentials(object):
             )
 
 
+def vsshape_has_files(shape:VSShape) -> bool:
+    """
+    Returns True if the given VSShape has any file URIs on it, or false otherwise.
+    Note that this does NOT include any non-file:// style URIs.
+    :param shape: VSShape
+    :return: True if the shape has at least one non-file:// URI present. Existence of the file is NOT checked.
+    """
+    for f in shape.fileURIs():
+        if f!="":
+            return True
+
+    return False
+
+
 ##START MAIN
 parser = ArgumentParser(description="Searches Vidispine for items that have no gnm_vidispine_id and requests updates for them")
 parser.add_argument("--vshost", default="localhost", help="Vidispine host")
@@ -144,7 +159,7 @@ ctr = 0
 for item in action.results(shouldPopulate=False):
     try:
         orig = item.get_shape("original")
-        if len(orig.fileURIs())<1:
+        if not vsshape_has_files(orig):
             logger.info("Original shape exists on {0} but without a file URI".format(item.name))
             continue
 

--- a/scripts/vidispine-no-nearlineid/requeue-missing-nearlineid.py
+++ b/scripts/vidispine-no-nearlineid/requeue-missing-nearlineid.py
@@ -142,11 +142,19 @@ if args.count:
 
 ctr = 0
 for item in action.results(shouldPopulate=False):
-    ctr += 1
-    logger.info("Sending event {0}/{1} for {2}....".format(ctr, action.totalItems, item.name))
-    send_message(rmq_chan, item.name)
-    if args.limit is not None and ctr>=int(args.limit):
-        logger.info("Hit limit of {0} items, completing".format(args.limit))
-        break
+    try:
+        orig = item.get_shape("original")
+        if len(orig.fileURIs())<1:
+            logger.info("Original shape exists on {0} but without a file URI".format(item.name))
+            continue
+
+        ctr += 1
+        logger.info("Sending event {0}/{1} for {2}....".format(ctr, action.totalItems, item.name))
+        send_message(rmq_chan, item.name)
+        if args.limit is not None and ctr>=int(args.limit):
+            logger.info("Hit limit of {0} items, completing".format(args.limit))
+            break
+    except VSNotFound:
+        logger.info("No original shape on {0}, skipping it".format(item.name))
 
 logger.info("All done.")


### PR DESCRIPTION
## What does this change?

- Reduces the default number of retries from 500 to 200
- Makes the retry count configurable in storagetier-nearline
- Ensure that placeholder items are skipped in the requeue-missing-nearlineid script

## How to test

Deploy to PROD and monitor the event count from storagetier-nearline in Kibana. It should start dropping.  There may well be alerts initially as a large number of retrying items get DLQ'd

## How can we measure success?
Less log noise
