### PR TITLE
Fix / incorrect filepath

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/FileDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/FileDocument.scala
@@ -10,7 +10,12 @@ case class FileItemRef(id:String)
 /**
 Represents a FileDocument metadata entry from Vidispine. Note that `uri` _can_ be None, e.g. in the case of state==LOST
  */
-case class FileDocument(id:String, path:String, uri:Option[Seq[String]], state:String, size:Long, hash:Option[String], timestamp:String,refreshFlag:Int, storage:String, item:Option[FileItemRef]) {
+case class FileDocument(id:String, path:String, uri:Option[Seq[String]], state:String, size:Long, hash:Option[String], timestamp:String,refreshFlag:Int, storage:String, item:Option[FileItemRef]) extends FileDocumentUtils
+
+trait FileDocumentUtils {
+  val uri:Option[Seq[String]]
+  val id:String
+
   private val logger = LoggerFactory.getLogger(getClass)
   /**
    * tries to parse the given URI string, check if it's a file: url and if so returns the path segment

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
@@ -15,7 +15,7 @@ case class VSShapeFile(
                       //field and it can cause parsing issues, keeping it as a String for the time being.
                       refreshFlag: Int,
                       storage: String,
-                      ) {
+                      ) extends FileDocumentUtils {
   def sizeOption = if(size == -1) None else Some(size)
 }
 

--- a/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -88,10 +88,11 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
     }
 
     "call out to uploadIfRequiredAndNotExists" in {
-      val mockVSFile = FileDocument("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
-      implicit val mockVSCommunicator = mock[VidispineCommunicator]
-      mockVSCommunicator.getFileInformation(any) returns Future(Some(mockVSFile))
 
+      val mockVSFile = VSShapeFile("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2")
+      implicit val mockVSCommunicator = mock[VidispineCommunicator]
+
+      mockVSCommunicator.findItemFile(any, any) returns Future(Some(mockVSFile))
       implicit val archiveHunterCommunicator = mock[ArchiveHunterCommunicator]
       implicit val mockUploader = mock[FileUploader]
       implicit val archivedRecordDAO:ArchivedRecordDAO = mock[ArchivedRecordDAO]


### PR DESCRIPTION

## What does this change?

fix accidental treatment of a proxy file as main media, by querying the original file from the itemid and not relying on the fileID for essenceVersion jobs

