### PR TITLE
Fix / update messages and file naming

### DIFF
--- a/online_archive/src/main/scala/AssetSweeperMessageProcessor.scala
+++ b/online_archive/src/main/scala/AssetSweeperMessageProcessor.scala
@@ -189,16 +189,11 @@ class AssetSweeperMessageProcessor(plutoCoreConfig:PlutoCoreConfig)
       case Left(err)=>
         Future(Left(s"Could not parse incoming message: $err"))
       case Right(newFile)=>
-        if (routingKey=="assetsweeper.asset_folder_importer.file.update") {
-          logger.warn("Received an update message, these are not implemented yet")
-          Future(Left("not implemented yet"))
-        } else {
-          for {
+        ( for {
             fullPath <- compositingGetPath(newFile)
             projectRecord <- asLookup.assetFolderProjectLookup(fullPath)
             result <- processFileAndProject(fullPath, projectRecord)
-          } yield result
-        }.recoverWith({
+          } yield result ).recoverWith({
           case err:Throwable=>
             val failure = FailureRecord(
               None,


### PR DESCRIPTION
## What does this change?

- removes the incremental file naming code (file-1, file-2 etc.) because we can manage this better with bucket versioning, which is now turned on. Object lock will prevent any accidental over-writes
- don't filter out asset sweeper "update" messages any more, there is no need to differentiate them

## How to test

Replay some "asset sweeper update" messages and watch them roll through
Keep an eye out for new versions being put onto existing files; the ingest lambda will update the index record for these to always point to the most recent version

## How can we measure success?

No looping whenever asset sweeper update messages come through

## Have we considered potential risks?

n/a
