### PR TITLE
Fix/common upload

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -68,7 +68,6 @@ lazy val `mxscopy` = (project in file("mxs-copy-components"))
       "com.typesafe.akka" %% "akka-agent" % "2.5.32",
       "com.typesafe.akka" %% "akka-http" % "10.2.6",
       "com.typesafe.akka" %% "akka-http-xml" % "10.2.6",
-      "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "3.0.3",
       "io.circe" %% "circe-core" % circeVersion,
       "io.circe" %% "circe-generic" % circeVersion,
       "io.circe" %% "circe-parser" % circeVersion,
@@ -105,7 +104,6 @@ lazy val `online_archive` = (project in file("online_archive"))
     dockerBaseImage := "openjdk:11-jdk-slim",
     dockerAlias := docker.DockerAlias(None,Some("guardianmultimedia"),"storagetier-online-archive",Some(sys.props.getOrElse("build.number","DEV"))),
     libraryDependencies ++= Seq(
-      "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "3.0.3",
       "com.typesafe.akka" %% "akka-http" % "10.2.6",
       "javax.xml.bind" % "jaxb-api" % "2.3.1",  //Fix "JAXB is unavailable." warning from AWS SDK
       "com.typesafe.akka" %% "akka-stream" % akkaVersion,
@@ -140,7 +138,6 @@ lazy val `online_nearline` = (project in file("online_nearline"))
     dockerBaseImage := "openjdk:8-jdk-slim-buster",
     dockerAlias := docker.DockerAlias(None,Some("guardianmultimedia"),"storagetier-online-nearline",Some(sys.props.getOrElse("build.number","DEV"))),
     libraryDependencies ++= Seq(
-      "com.lightbend.akka" %% "akka-stream-alpakka-s3" % "3.0.3",
       "com.typesafe.akka" %% "akka-http" % "10.2.6",
       "com.typesafe.akka" %% "akka-stream" % akkaVersion,
       "com.typesafe.akka" %% "akka-slf4j" % akkaVersion,

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/UriListDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/UriListDocument.scala
@@ -1,3 +1,12 @@
 package com.gu.multimedia.storagetier.vidispine
 
 case class UriListDocument (uri:Seq[String])
+
+/**
+ * if there are no thumnbnails we get an empty _object_ rather than an empty _sequence_. This is modelled here.
+ * @param uri
+ */
+case class OptionalUriListDocument (uri:Option[Seq[String]]) {
+  def toUriListDocument = UriListDocument(uri.getOrElse(Seq()))
+  def toOption = uri.map(UriListDocument.apply)
+}

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
@@ -136,11 +136,11 @@ class VidispineCommunicator(config:VidispineConfig) (implicit ec:ExecutionContex
       case None=>HttpRequest(uri = baseUriString)
       case Some(version)=>HttpRequest(uri = baseUriString + s"?version=$version")
     }
-    callToVidispine[UriListDocument](req)
+    callToVidispine[OptionalUriListDocument](req).map(_.flatMap(_.toOption))
   }
 
   protected def getThumbnailsList(maybeResourceUri:Option[String]) = maybeResourceUri.map(thumbnailResourceUri=>
-      callToVidispine[UriListDocument](HttpRequest(uri = thumbnailResourceUri))
+      callToVidispine[OptionalUriListDocument](HttpRequest(uri = thumbnailResourceUri)).map(_.flatMap(_.toOption))
   ).sequence.map(_.flatten)
 
   protected def findFirstThumbnail(maybeResourceUri:Option[String], maybeThumbnailsList:Option[UriListDocument]) = {

--- a/online_archive/src/main/scala/AssetSweeperMessageProcessor.scala
+++ b/online_archive/src/main/scala/AssetSweeperMessageProcessor.scala
@@ -193,11 +193,11 @@ class AssetSweeperMessageProcessor(plutoCoreConfig:PlutoCoreConfig)
       case Right(newFile)=>
         if(newFile.ignore) {
           logger.info(s"File ${newFile.filepath}/${newFile.filename} is marked as ignored")
-          throw SilentDropMessage(Some("Ignored file"))
+          Future.failed(SilentDropMessage(Some("Ignored file")))
         }
         if(isPreview.unanchored.matches(newFile.filepath)) {
           logger.info(s"Filepath ${newFile.filepath} indicates preview files, not archiving")
-          throw SilentDropMessage(Some("Preview file"))
+          Future.failed(SilentDropMessage(Some("Preview file")))
         }
         ( for {
             fullPath <- compositingGetPath(newFile)

--- a/online_archive/src/main/scala/VidispineFunctions.scala
+++ b/online_archive/src/main/scala/VidispineFunctions.scala
@@ -294,9 +294,9 @@ class VidispineFunctions(mediaFileUploader:FileUploader, proxyFileUploader:FileU
         val uploadedPathXtn = FilenameSplitter(archivedRecord.uploadedPath)
         val thumbnailPath = uploadedPathXtn._1 + "_thumb.jpg"
         val result = for {
-          uploadResult <- proxyFileUploader.uploadAkkaStream(streamSource.dataBytes, thumbnailPath, streamSource.contentType, streamSource.contentLengthOption, allowOverwrite = true)
-          _ <- archiveHunterCommunicator.importProxy(archivedRecord.archiveHunterID, uploadResult.key, uploadResult.bucket, ArchiveHunter.ProxyType.THUMBNAIL)
-        } yield uploadResult.location
+          uploadResult <- proxyFileUploader.uploadAkkaStream(streamSource.dataBytes, thumbnailPath, streamSource.contentType, streamSource.contentLengthOption)
+          _ <- archiveHunterCommunicator.importProxy(archivedRecord.archiveHunterID, thumbnailPath, proxyFileUploader.bucketName, ArchiveHunter.ProxyType.THUMBNAIL)
+        } yield uploadResult
         result.map(_=>Right( () ) ) //throw away the final result, we just need to know it worked.
     })
   }
@@ -312,11 +312,11 @@ class VidispineFunctions(mediaFileUploader:FileUploader, proxyFileUploader:FileU
         val metadataPath = uploadedPathXtn._1 + "_metadata.xml"
 
         for {
-          uploadResult <- proxyFileUploader.uploadAkkaStream(entity.dataBytes, metadataPath, entity.contentType, entity.contentLengthOption, allowOverwrite = true)
-          _ <- archiveHunterCommunicator.importProxy(archivedRecord.archiveHunterID, uploadResult.key, uploadResult.bucket, ArchiveHunter.ProxyType.METADATA)
+          uploadResult <- proxyFileUploader.uploadAkkaStream(entity.dataBytes, metadataPath, entity.contentType, entity.contentLengthOption)
+          _ <- archiveHunterCommunicator.importProxy(archivedRecord.archiveHunterID, metadataPath, proxyFileUploader.bucketName, ArchiveHunter.ProxyType.METADATA)
           updatedRecord <- Future(archivedRecord.copy(
-            proxyBucket = Some(uploadResult.bucket),
-            metadataXML = Some(uploadResult.key),
+            proxyBucket = Some(proxyFileUploader.bucketName),
+            metadataXML = Some(metadataPath),
             metadataVersion = essenceVersion
           ))
           _ <- archivedRecordDAO.writeRecord(updatedRecord)

--- a/online_archive/src/main/scala/VidispineFunctions.scala
+++ b/online_archive/src/main/scala/VidispineFunctions.scala
@@ -294,7 +294,7 @@ class VidispineFunctions(mediaFileUploader:FileUploader, proxyFileUploader:FileU
         val uploadedPathXtn = FilenameSplitter(archivedRecord.uploadedPath)
         val thumbnailPath = uploadedPathXtn._1 + "_thumb.jpg"
         val result = for {
-          uploadResult <- proxyFileUploader.uploadAkkaStream(streamSource.dataBytes, thumbnailPath, streamSource.contentType, streamSource.contentLengthOption)
+          uploadResult <- proxyFileUploader.uploadAkkaStreamViaTempfile(streamSource.dataBytes, thumbnailPath, streamSource.contentType)
           _ <- archiveHunterCommunicator.importProxy(archivedRecord.archiveHunterID, thumbnailPath, proxyFileUploader.bucketName, ArchiveHunter.ProxyType.THUMBNAIL)
         } yield uploadResult
         result.map(_=>Right( () ) ) //throw away the final result, we just need to know it worked.
@@ -312,7 +312,7 @@ class VidispineFunctions(mediaFileUploader:FileUploader, proxyFileUploader:FileU
         val metadataPath = uploadedPathXtn._1 + "_metadata.xml"
 
         for {
-          uploadResult <- proxyFileUploader.uploadAkkaStream(entity.dataBytes, metadataPath, entity.contentType, entity.contentLengthOption)
+          uploadResult <- proxyFileUploader.uploadAkkaStreamViaTempfile(entity.dataBytes, metadataPath, entity.contentType)
           _ <- archiveHunterCommunicator.importProxy(archivedRecord.archiveHunterID, metadataPath, proxyFileUploader.bucketName, ArchiveHunter.ProxyType.METADATA)
           updatedRecord <- Future(archivedRecord.copy(
             proxyBucket = Some(proxyFileUploader.bucketName),

--- a/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -1,9 +1,6 @@
 import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentType, HttpEntity}
 import akka.stream.Materializer
-import akka.stream.alpakka.s3.MultipartUploadResult
-import akka.stream.scaladsl.Source
-import akka.util.ByteString
 import io.circe.syntax.EncoderOps
 import archivehunter.ArchiveHunterCommunicator
 import com.gu.multimedia.storagetier.framework.{MessageProcessorReturnValue, SilentDropMessage}


### PR DESCRIPTION
## What does this change?

Deprecates direct stream upload via Alpakka, as it is not working properly with ObjectLock protected buckets. Instead, use the S3 transfer library

## How to test

Deploy and then ingest media to Vidispine.  The alpakka upload was used for metadata/thumbs and was erroring and retrying in the logs. You should see them succeed

## How can we measure success?

Less errors and DLQs
