### PR TITLE
Split image builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
     branches: [ main ]
 
 jobs:
-  build:
+  online_archive:
     runs-on: ubuntu-latest
     # The first two permissions are needed to interact with GitHub's OIDC Token endpoint.
     # The second set of two permissions are needed to write test results back to GH
@@ -66,12 +66,105 @@ jobs:
       - run: if [ -d "junit-tests" ]; then mkdir junit-tests; fi
         name: Prepare test outputs location
 
-      - name: Build and test everything
+      - name: Build and test online_archive
         env:
           JAVA_OPTS: "-Dbuild.number=${{ env.GITHUB_RUN_NUMBER }}"
           SBT_JUNIT_OUTPUT: ./junit-tests
           DB_PORT: ${{ job.services.postgres.ports[5432] }}
-        run: sbt -v "test; docker:publishLocal"
+        run: sbt -v "project online_archive; test; docker:publishLocal"
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()  #runs even if there is a test failure
+        with:
+          files: junit-tests/*.xml
+
+      - name: Tag docker image online-archive
+        run:  docker tag guardianmultimedia/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }} ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }}
+
+      - name: Push docker image online-archive
+        run: docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }}
+
+      - name: Output build-info.yaml
+        uses: fredex42/pluto-build-info@v1.1
+        with:
+          builtimage: AWS_ACCOUNT_ID.dkr.ecr.AWS_REGION.amazonaws.com/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check the output
+        run: cat build-info.yaml
+
+      - name: Upload build info
+        uses: actions/upload-artifact@v3
+        with:
+          name: build-info
+          path: build-info.yaml
+
+  online_nearline:
+    runs-on: ubuntu-latest
+    # The first two permissions are needed to interact with GitHub's OIDC Token endpoint.
+    # The second set of two permissions are needed to write test results back to GH
+    permissions:
+      id-token: write
+      contents: read
+      checks: write
+      pull-requests: write
+
+    services:
+      postgres:
+        image: postgres:13-alpine
+        env:
+          POSTGRES_DB: storagetier-test
+          POSTGRES_PASSWORD: storagetier-test
+          POSTGRES_USER: storagetier
+        ports:
+          - "5432/tcp"
+        # needed because the postgres container does not provide a healthcheck
+        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+
+    env:
+      POSTGRES_DB: storagetier-test
+      POSTGRES_PASSWORD: storagetier-test
+      POSTGRES_USER: storagetier
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup JDK
+        uses: actions/setup-java@v2
+        with:
+          distribution: temurin
+          java-version: 8
+
+      # GITHUB_RUN_NUMBER always starts from 1, so to maintain compatibility we adjust it here
+      - name: Make GITHUB_RUN_NUMBER env var available outside of shells
+        working-directory: ${{env.GITHUB_WORKSPACE}}
+        shell: bash
+        run: |
+          echo GITHUB_RUN_NUMBER=$(( GITHUB_RUN_NUMBER + 279 ))>> $GITHUB_ENV
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: GHA-build
+
+      - name: ECR Login
+        run: aws ecr get-login-password --region ${{ secrets.AWS_REGION }} | docker login --username AWS --password-stdin ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - run: if [ -d "junit-tests" ]; then mkdir junit-tests; fi
+        name: Prepare test outputs location
+
+      - name: Build and test online_nearline
+        env:
+          JAVA_OPTS: "-Dbuild.number=${{ env.GITHUB_RUN_NUMBER }}"
+          SBT_JUNIT_OUTPUT: ./junit-tests
+          DB_PORT: ${{ job.services.postgres.ports[5432] }}
+        run: sbt -v "project online_nearline; test; docker:publishLocal"
 
       - name: Publish Unit Test Results
         uses: EnricoMi/publish-unit-test-result-action@v1
@@ -84,12 +177,6 @@ jobs:
 
       - name: Push docker image online-nearline
         run: docker push  ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-nearline:${{ env.GITHUB_RUN_NUMBER }}
-
-      - name: Tag docker image online-archive
-        run:  docker tag guardianmultimedia/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }} ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }}
-
-      - name: Push docker image online-archive
-        run: docker push ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }}
 
       - name: Output build-info.yaml
         uses: fredex42/pluto-build-info@v1.1
@@ -105,4 +192,3 @@ jobs:
         with:
           name: build-info
           path: build-info.yaml
-

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -78,6 +78,8 @@ jobs:
         if: always()  #runs even if there is a test failure
         with:
           files: junit-tests/*.xml
+          check_name: Online-Archive Tests
+          comment_title: Online-Archive Tests
 
       - name: Tag docker image online-archive
         run:  docker tag guardianmultimedia/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }} ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-archive:${{ env.GITHUB_RUN_NUMBER }}
@@ -171,7 +173,8 @@ jobs:
         if: always()  #runs even if there is a test failure
         with:
           files: junit-tests/*.xml
-
+          check_name: Online-Nearline Tests
+          comment_title: Online-Nearline Tests
       - name: Tag docker image online-nearline
         run:  docker tag guardianmultimedia/storagetier-online-nearline:${{ env.GITHUB_RUN_NUMBER }} ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.AWS_REGION }}.amazonaws.com/storagetier-online-nearline:${{ env.GITHUB_RUN_NUMBER }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,7 +99,7 @@ jobs:
       - name: Upload build info
         uses: actions/upload-artifact@v3
         with:
-          name: build-info
+          name: online_archive
           path: build-info.yaml
 
   online_nearline:
@@ -193,5 +193,5 @@ jobs:
       - name: Upload build info
         uses: actions/upload-artifact@v3
         with:
-          name: build-info
+          name: online_nearline
           path: build-info.yaml


### PR DESCRIPTION
## What does this change?

- splits online_nearline and online_archive into seperate builds to make versions-manager integration easier
- renames the build-info artifacts so versions-manager can distinguish them
- 
## How to test

Just check that the build runs fine, two jobs should run in parallel
