### PR TITLE
Feature/gp 632 log correlation

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
@@ -19,7 +19,7 @@ object NearlineRecord extends ((Option[Int], String, String, Option[String], Opt
   Option[Boolean], Boolean, String) =>
   NearlineRecord ) {
   def apply(objectId:String, originalFilePath:String, correlationId: String) = {
-    new NearlineRecord(None, objectId, originalFilePath, None, None, None, None, None, correlationId)
+    new NearlineRecord(None, objectId, originalFilePath, None, None, None, None, None, false, correlationId)
   }
 }
 

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
@@ -1,5 +1,6 @@
 package com.gu.multimedia.storagetier.models.nearline_archive
 
+import org.slf4j.MDC
 import slick.jdbc.PostgresProfile.api._
 
 case class NearlineRecord(id:Option[Int],
@@ -19,6 +20,7 @@ object NearlineRecord extends ((Option[Int], String, String, Option[String], Opt
   Option[Boolean], Boolean, String) =>
   NearlineRecord ) {
   def apply(objectId:String, originalFilePath:String, correlationId: String) = {
+    MDC.put("correlationId", correlationId)
     new NearlineRecord(None, objectId, originalFilePath, None, None, None, None, None, false, correlationId)
   }
 }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
@@ -11,12 +11,15 @@ case class NearlineRecord(id:Option[Int],
                           metadataXMLObjectId:Option[String],
                           internallyArchived:Option[Boolean]=None,
                           expectingVidispineId:Boolean=true,
+                          correlationId:String
                          )
 
-object NearlineRecord extends ((Option[Int], String, String, Option[String], Option[Int], Option[String], Option[String], Option[Boolean], Boolean) =>
+
+object NearlineRecord extends ((Option[Int], String, String, Option[String], Option[Int], Option[String], Option[String],
+  Option[Boolean], Boolean, String) =>
   NearlineRecord ) {
-  def apply(objectId:String, originalFilePath:String) = {
-    new NearlineRecord(None, objectId, originalFilePath, None, None, None, None, None)
+  def apply(objectId:String, originalFilePath:String, correlationId: String) = {
+    new NearlineRecord(None, objectId, originalFilePath, None, None, None, None, None, correlationId)
   }
 }
 
@@ -30,7 +33,7 @@ class NearlineRecordRow (tag:Tag) extends Table[NearlineRecord](tag, "nearlinear
   def metadataXMLObjectId = column[Option[String]]("s_metadata_xml_objectid")
   def internallyArchived = column[Option[Boolean]]("b_internally_archived")
   def expectingVidispineId = column[Boolean]("b_expecting_vidispine_id")
+  def correlationId = column[String]("s_correlation_id")
 
-  def * = (id.?, objectId, originalFilePath, vidispineItemId, vidispineVersionId, proxyObjectId, metadataXMLObjectId, internallyArchived, expectingVidispineId) <>
-    (NearlineRecord.tupled, NearlineRecord.unapply)
+  def * = (id.?, objectId, originalFilePath, vidispineItemId, vidispineVersionId, proxyObjectId, metadataXMLObjectId, internallyArchived, expectingVidispineId, correlationId) <> (NearlineRecord.tupled, NearlineRecord.unapply)
 }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecordDAO.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecordDAO.scala
@@ -1,7 +1,7 @@
 package com.gu.multimedia.storagetier.models.nearline_archive
 
 import com.gu.multimedia.storagetier.models.GenericDAO
-import org.slf4j.LoggerFactory
+import org.slf4j.{LoggerFactory, MDC}
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.meta.MTable
@@ -58,6 +58,10 @@ class NearlineRecordDAO(override protected val db:Database)(implicit ec:Executio
   override def getRecord(pk: Int): Future[Option[NearlineRecord]] = db.run(
     TableQuery[NearlineRecordRow].filter(_.id===pk).result
   ).map(_.headOption)
+    .map(maybeRecord=>{
+      maybeRecord.foreach(rec=>MDC.put("correlationId", rec.correlationId))
+      maybeRecord
+    })
 
   def findBySourceFilename(filename:String) = db.run(
     TableQuery[NearlineRecordRow].filter(_.originalFilePath===filename).result

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecord.scala
@@ -1,5 +1,6 @@
 package com.gu.multimedia.storagetier.models.online_archive
 
+import org.slf4j.MDC
 import slick.jdbc.PostgresProfile.api._
 
 /*
@@ -34,6 +35,7 @@ object ArchivedRecord extends ((Option[Int], String, Boolean, String, Long, Stri
   Option[String], Option[String], Option[Int], Option[String], Option[Int], String) => ArchivedRecord ){
   def apply(archiveHunterID:String, originalFilePath:String, originalFileSize: Long, uploadedBucket:String, uploadedPath:String,
             uploadedVersion:Option[Int], correlationId: String) = {
+    MDC.put("correlationId", correlationId)
     new ArchivedRecord(None, archiveHunterID, false, originalFilePath, originalFileSize, uploadedBucket, uploadedPath,
       uploadedVersion, None,None,None,None,None,None,None, correlationId)
   }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecord.scala
@@ -26,15 +26,16 @@ case class ArchivedRecord(id:Option[Int],
                           proxyPath:Option[String],
                           proxyVersion:Option[Int],
                           metadataXML:Option[String],
-                          metadataVersion:Option[Int]
+                          metadataVersion:Option[Int],
+                          correlationId:String
                          )
 
 object ArchivedRecord extends ((Option[Int], String, Boolean, String, Long, String, String, Option[Int], Option[String], Option[Int],
-  Option[String], Option[String], Option[Int], Option[String], Option[Int]) => ArchivedRecord ){
+  Option[String], Option[String], Option[Int], Option[String], Option[Int], String) => ArchivedRecord ){
   def apply(archiveHunterID:String, originalFilePath:String, originalFileSize: Long, uploadedBucket:String, uploadedPath:String,
-            uploadedVersion:Option[Int]) = {
+            uploadedVersion:Option[Int], correlationId: String) = {
     new ArchivedRecord(None, archiveHunterID, false, originalFilePath, originalFileSize, uploadedBucket, uploadedPath,
-      uploadedVersion, None,None,None,None,None,None,None)
+      uploadedVersion, None,None,None,None,None,None,None, correlationId)
   }
 }
 
@@ -54,11 +55,12 @@ class ArchivedRecordRow (tag:Tag) extends Table[ArchivedRecord](tag, "onlinearch
   def proxyVersion = column[Option[Int]]("i_proxy_version")
   def metadataXML = column[Option[String]]("s_metadata_xml_path")
   def metadataVersion = column[Option[Int]]("i_metadata_version")
+  def correlationId = column[String]("s_correlation_id")
 
   def filepathIdx = index("filepath_idx", originalFilePath)
   def archiveHunterIdIds = index("archivehunter_id_idx", archiveHunterID, unique = true)
   def vidispineIdIdx = index("vidispine_item_idx", vidispineItemId)
 
   def * = (id.?, archiveHunterID, archiveHunterIDValidated, originalFilePath, originalFileSize, uploadedBucket, uploadedPath,
-    uploadedVersion, vidispineItemId, vidispineVersionId, proxyBucket, proxyPath, proxyVersion, metadataXML, metadataVersion) <> (ArchivedRecord.tupled, ArchivedRecord.unapply)
+    uploadedVersion, vidispineItemId, vidispineVersionId, proxyBucket, proxyPath, proxyVersion, metadataXML, metadataVersion, correlationId) <> (ArchivedRecord.tupled, ArchivedRecord.unapply)
 }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecordDAO.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecordDAO.scala
@@ -1,5 +1,6 @@
 package com.gu.multimedia.storagetier.models.online_archive
 import com.gu.multimedia.storagetier.models.GenericDAO
+import org.slf4j.MDC
 import slick.jdbc.PostgresProfile.api._
 import slick.jdbc.JdbcBackend.Database
 import slick.jdbc.meta.MTable
@@ -71,6 +72,11 @@ class ArchivedRecordDAO(override protected val db:Database)(implicit ec:Executio
   override def getRecord(pk: Int): Future[Option[ArchivedRecord]] = db.run(
     TableQuery[ArchivedRecordRow].filter(_.id===pk).result
   ).map(_.headOption)
+    .map(maybeRecord=>{
+      maybeRecord.foreach(rec=>MDC.put("correlationId", rec.correlationId))
+      maybeRecord
+    })
+
 
   def findBySourceFilename(filename:String) = db.run(
     TableQuery[ArchivedRecordRow].filter(_.originalFilePath===filename).result

--- a/common/src/test/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecordDAOSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecordDAOSpec.scala
@@ -5,6 +5,8 @@ import org.specs2.specification.{AfterEach, Before, BeforeAll}
 import slick.jdbc.JdbcBackend.Database
 import slick.lifted.TableQuery
 import slick.jdbc.PostgresProfile.api._
+
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -42,7 +44,7 @@ class NearlineRecordDAOSpec extends Specification with BeforeAll with AfterEach 
   "NearlineRecordDAO.writeRecord" should {
     "insert a new record, and update it" in {
       //insert a new record, make sure we got something that looks like an id
-      val rec = NearlineRecord(None,"test-id","/path/to/original-file",None, None, None, None)
+      val rec = NearlineRecord(None,"test-id","/path/to/original-file",None, None, None, None, correlationId = UUID.randomUUID().toString)
 
       val result = Await.result(dao.writeRecord(rec), 2.seconds)
       result must beGreaterThanOrEqualTo (1)
@@ -67,7 +69,7 @@ class NearlineRecordDAOSpec extends Specification with BeforeAll with AfterEach 
     }
 
     "fail if we try to update a record that does not exist" in {
-      val rec = NearlineRecord(Some(123),"test-nonexistent-id","/path/to/original-file",None, None, None, None)
+      val rec = NearlineRecord(Some(123),"test-nonexistent-id","/path/to/original-file",None, None, None, None, correlationId = UUID.randomUUID().toString)
 
       val result = Try { Await.result(dao.writeRecord(rec), 2.seconds) }
       result must beAFailedTry
@@ -77,7 +79,7 @@ class NearlineRecordDAOSpec extends Specification with BeforeAll with AfterEach 
 
   "NearlineRecordDAO.deleteRecord" should {
     "delete an existing record" in {
-      val rec = NearlineRecord(None,"test-id-to-delete","/path/to/original-file",None, None, None, None)
+      val rec = NearlineRecord(None,"test-id-to-delete","/path/to/original-file",None, None, None, None, correlationId = UUID.randomUUID().toString)
 
       val insertedId = Await.result(db.run(TableQuery[NearlineRecordRow] returning TableQuery[NearlineRecordRow].map(_.id) += rec), 2.seconds)
       val updatedRec = rec.copy(id=Some(insertedId))
@@ -97,7 +99,7 @@ class NearlineRecordDAOSpec extends Specification with BeforeAll with AfterEach 
 
   "NearlineRecordDAO.deleteRecordByID" should {
     "delete an existing record" in {
-      val rec = NearlineRecord(None,"test-id-to-delete","/path/to/original-file",None, None, None, None)
+      val rec = NearlineRecord(None,"test-id-to-delete","/path/to/original-file",None, None, None, None, correlationId = UUID.randomUUID().toString)
 
       val insertedId = Await.result(db.run(TableQuery[NearlineRecordRow] returning TableQuery[NearlineRecordRow].map(_.id) += rec), 2.seconds)
 

--- a/common/src/test/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecordDAOSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecordDAOSpec.scala
@@ -5,6 +5,8 @@ import org.specs2.specification.{AfterEach, Before, BeforeAll}
 import slick.jdbc.JdbcBackend.Database
 import slick.lifted.TableQuery
 import slick.jdbc.PostgresProfile.api._
+
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.Await
@@ -43,7 +45,7 @@ class ArchivedRecordDAOSpec extends Specification with BeforeAll with AfterEach 
     "insert a new record, and update it" in {
       //insert a new record, make sure we got something that looks like an id
       val rec = ArchivedRecord(None,"test-id",false,"/path/to/original-file",100,"somebucket","/path/to/archived-file",Some(1), None,
-      None, None, None, None, None, None)
+      None, None, None, None, None, None, UUID.randomUUID().toString)
 
       val result = Await.result(dao.writeRecord(rec), 2.seconds)
       result must beGreaterThanOrEqualTo (1)
@@ -69,7 +71,7 @@ class ArchivedRecordDAOSpec extends Specification with BeforeAll with AfterEach 
 
     "fail if we try to update a record that does not exist" in {
       val rec = ArchivedRecord(Some(123),"test-nonexistent-id",false,"/path/to/original-file",100,"somebucket",
-      "/path/to/archived-file",Some(1), None, None, None, None, None, None, None)
+      "/path/to/archived-file",Some(1), None, None, None, None, None, None, None, UUID.randomUUID().toString)
 
       val result = Try { Await.result(dao.writeRecord(rec), 2.seconds) }
       result must beAFailedTry
@@ -80,7 +82,7 @@ class ArchivedRecordDAOSpec extends Specification with BeforeAll with AfterEach 
   "ArchivedRecordDAO.deleteRecord" should {
     "delete an existing record" in {
       val rec = ArchivedRecord(None,"test-id-to-delete",false,"/path/to/original-file",100,"somebucket","/path/to/archived-file",Some
-      (1), None, None, None, None, None, None, None)
+      (1), None, None, None, None, None, None, None, UUID.randomUUID().toString)
 
       val insertedId = Await.result(db.run(TableQuery[ArchivedRecordRow] returning TableQuery[ArchivedRecordRow].map(_.id) += rec), 2.seconds)
       val updatedRec = rec.copy(id=Some(insertedId))
@@ -99,7 +101,7 @@ class ArchivedRecordDAOSpec extends Specification with BeforeAll with AfterEach 
   "ArchivedRecordDAO.deleteRecordByID" should {
     "delete an existing record" in {
       val rec = ArchivedRecord(None,"test-id-to-delete",false,"/path/to/original-file",100,"somebucket","/path/to/archived-file",Some
-      (1), None, None, None, None, None, None, None)
+      (1), None, None, None, None, None, None, None, UUID.randomUUID().toString)
 
       val insertedId = Await.result(db.run(TableQuery[ArchivedRecordRow] returning TableQuery[ArchivedRecordRow].map(_.id) += rec), 2.seconds)
 

--- a/online_archive/src/main/resources/logback.xml
+++ b/online_archive/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZ} [%thread] [%X{msgId};%X{retryAttempt};%X{routingKey};%X{exchange};%X{isRedeliver}] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZ} [%thread] [%X{msgId};%X{retryAttempt};%X{routingKey};%X{exchange};%X{isRedeliver};%X{correlationId}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/online_archive/src/main/scala/AssetSweeperMessageProcessor.scala
+++ b/online_archive/src/main/scala/AssetSweeperMessageProcessor.scala
@@ -43,11 +43,13 @@ class AssetSweeperMessageProcessor(plutoCoreConfig:PlutoCoreConfig)
       Paths.get(newFile.filepath, newFile.filename)
     })
 
+  protected def getCorrelationId:String = UUID.randomUUID().toString
   private def callUpload(fullPath:Path, relativePath:Path) = {
     logger.info(s"Archiving file '$fullPath' to s3://${uploader.bucketName}/$relativePath")
       uploader.copyFileToS3(fullPath.toFile, Some(relativePath.toString)).flatMap((fileInfo)=>{
       val (fileName, fileSize) = fileInfo
-      val correlationId = UUID.randomUUID().toString
+      val correlationId = getCorrelationId
+
       MDC.put("correlationId", correlationId)
 
       logger.debug(s"$fullPath: Upload completed")

--- a/online_archive/src/main/scala/VidispineFunctions.scala
+++ b/online_archive/src/main/scala/VidispineFunctions.scala
@@ -104,7 +104,8 @@ class VidispineFunctions(mediaFileUploader:FileUploader, proxyFileUploader:FileU
             None,
             None,
             None,
-            None
+            None,
+            "corrid"
           )
       }
 

--- a/online_archive/src/main/scala/VidispineFunctions.scala
+++ b/online_archive/src/main/scala/VidispineFunctions.scala
@@ -157,6 +157,7 @@ class VidispineFunctions(mediaFileUploader:FileUploader, proxyFileUploader:FileU
           Future(Left(s"${filePath} should be ignored due to reason ${ignoreRecord.ignoreReason}"))
         case (None, Some(archivedRecord)) =>
           showPreviousFailure(maybeFailureRecord, filePath)
+          MDC.put("correlationId", archivedRecord.correlationId)
 
           if(archivedRecord.archiveHunterID.isEmpty || !archivedRecord.archiveHunterIDValidated) {
             logger.info(s"Archive hunter ID does not exist yet for filePath $filePath, will retry")

--- a/online_archive/src/test/scala/AssetSweeperMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/AssetSweeperMessageProcessorSpec.scala
@@ -53,10 +53,12 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         ProductionOffice.UK
       )
       val basePath = Paths.get("/media/assets")
-      val toTest = new AssetSweeperMessageProcessor(PlutoCoreConfig("https://fake-server","notsecret",basePath))
+      val toTest = new AssetSweeperMessageProcessor(PlutoCoreConfig("https://fake-server","notsecret",basePath)) {
+        override protected def getCorrelationId: String = "af1bf7e4-f576-4f48-b583-948798036cae"
+      }
 
       val result = Await.result(toTest.processFileAndProject(Paths.get("/media/assets/path/to/file.ext"), Some(projectRecord)), 2.seconds)
-      val expectedJson = """{"id":123,"archiveHunterID":"c29tZWJ1Y2tldDp1cGxvYWRlZC9wYXRoL3RvL2ZpbGUuZXh0","archiveHunterIDValidated":false,"originalFilePath":"/media/assets/path/to/file.ext","originalFileSize":100,"uploadedBucket":"somebucket","uploadedPath":"uploaded/path/to/file.ext","uploadedVersion":null,"vidispineItemId":null,"vidispineVersionId":null,"proxyBucket":null,"proxyPath":null,"proxyVersion":null,"metadataXML":null,"metadataVersion":null}"""
+      val expectedJson = """{"id":123,"archiveHunterID":"c29tZWJ1Y2tldDp1cGxvYWRlZC9wYXRoL3RvL2ZpbGUuZXh0","archiveHunterIDValidated":false,"originalFilePath":"/media/assets/path/to/file.ext","originalFileSize":100,"uploadedBucket":"somebucket","uploadedPath":"uploaded/path/to/file.ext","uploadedVersion":null,"vidispineItemId":null,"vidispineVersionId":null,"proxyBucket":null,"proxyPath":null,"proxyVersion":null,"metadataXML":null,"metadataVersion":null,"correlationId":"af1bf7e4-f576-4f48-b583-948798036cae"}"""
       result.map(_.content.noSpaces) must beRight(expectedJson)
       there was one(archivedRecordDAO).findBySourceFilename("/media/assets/path/to/file.ext")
       there was one(archivedRecordDAO).writeRecord(any)
@@ -98,11 +100,14 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         ProductionOffice.UK
       )
       val basePath = Paths.get("/completely/random/base/path")
-      val toTest = new AssetSweeperMessageProcessor(PlutoCoreConfig("https://fake-server","notsecret",basePath))
+
+      val toTest = new AssetSweeperMessageProcessor(PlutoCoreConfig("https://fake-server","notsecret",basePath)) {
+        override protected def getCorrelationId: String = "af1bf7e4-f576-4f48-b583-948798036cae"
+      }
 
       val result = Await.result(toTest.processFileAndProject(Paths.get("/media/assets/path/to/file.ext"), Some(projectRecord)), 2.seconds)
       val expectedJson =
-        """{"id":123,"archiveHunterID":"c29tZWJ1Y2tldDptZWRpYS9hc3NldHMvcGF0aC90by9maWxlLmV4dA==","archiveHunterIDValidated":false,"originalFilePath":"/media/assets/path/to/file.ext","originalFileSize":100,"uploadedBucket":"somebucket","uploadedPath":"media/assets/path/to/file.ext","uploadedVersion":null,"vidispineItemId":null,"vidispineVersionId":null,"proxyBucket":null,"proxyPath":null,"proxyVersion":null,"metadataXML":null,"metadataVersion":null}""".stripMargin
+        """{"id":123,"archiveHunterID":"c29tZWJ1Y2tldDptZWRpYS9hc3NldHMvcGF0aC90by9maWxlLmV4dA==","archiveHunterIDValidated":false,"originalFilePath":"/media/assets/path/to/file.ext","originalFileSize":100,"uploadedBucket":"somebucket","uploadedPath":"media/assets/path/to/file.ext","uploadedVersion":null,"vidispineItemId":null,"vidispineVersionId":null,"proxyBucket":null,"proxyPath":null,"proxyVersion":null,"metadataXML":null,"metadataVersion":null,"correlationId":"af1bf7e4-f576-4f48-b583-948798036cae"}""".stripMargin
       result.map(_.content.noSpaces) must beRight(expectedJson)
       there was one(archivedRecordDAO).findBySourceFilename("/media/assets/path/to/file.ext")
       there was one(archivedRecordDAO).writeRecord(any)
@@ -129,10 +134,12 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       uploader.bucketName returns "somebucket"
 
       val basePath = Paths.get("/media/assets")
-      val toTest = new AssetSweeperMessageProcessor(PlutoCoreConfig("https://fake-server","notsecret",basePath))
+      val toTest = new AssetSweeperMessageProcessor(PlutoCoreConfig("https://fake-server","notsecret",basePath)) {
+        override protected def getCorrelationId: String = "af1bf7e4-f576-4f48-b583-948798036cae"
+      }
 
       val result = Await.result(toTest.processFileAndProject(Paths.get("/media/assets/path/to/file.ext"), None), 2.seconds)
-      val expectedJson = """{"id":123,"archiveHunterID":"c29tZWJ1Y2tldDp1cGxvYWRlZC9wYXRoL3RvL2ZpbGUuZXh0","archiveHunterIDValidated":false,"originalFilePath":"/media/assets/path/to/file.ext","originalFileSize":100,"uploadedBucket":"somebucket","uploadedPath":"uploaded/path/to/file.ext","uploadedVersion":null,"vidispineItemId":null,"vidispineVersionId":null,"proxyBucket":null,"proxyPath":null,"proxyVersion":null,"metadataXML":null,"metadataVersion":null}"""
+      val expectedJson = """{"id":123,"archiveHunterID":"c29tZWJ1Y2tldDp1cGxvYWRlZC9wYXRoL3RvL2ZpbGUuZXh0","archiveHunterIDValidated":false,"originalFilePath":"/media/assets/path/to/file.ext","originalFileSize":100,"uploadedBucket":"somebucket","uploadedPath":"uploaded/path/to/file.ext","uploadedVersion":null,"vidispineItemId":null,"vidispineVersionId":null,"proxyBucket":null,"proxyPath":null,"proxyVersion":null,"metadataXML":null,"metadataVersion":null,"correlationId":"af1bf7e4-f576-4f48-b583-948798036cae"}"""
       result.map(_.content.noSpaces) must beRight(expectedJson)
       there was one(archivedRecordDAO).findBySourceFilename("/media/assets/path/to/file.ext")
       there was one(archivedRecordDAO).writeRecord(any)

--- a/online_archive/src/test/scala/OwnMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/OwnMessageProcessorSpec.scala
@@ -13,6 +13,7 @@ import io.circe.syntax._
 import messages.RevalidateArchiveHunterRequest
 import com.gu.multimedia.storagetier.framework.MessageProcessorConverters._
 import java.time.ZonedDateTime
+import java.util.UUID
 import scala.concurrent.duration._
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.{Await, Future}
@@ -52,7 +53,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
         None,
         None,
         None,
-        None
+        None,
+        UUID.randomUUID().toString
       )
       val result = Await.result(toTest.handleArchivehunterValidation(incomingRecord), 3.seconds)
 
@@ -94,7 +96,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
         None,
         None,
         None,
-        None
+        None,
+        UUID.randomUUID().toString
       )
       val result = Await.result(toTest.handleArchivehunterValidation(incomingRecord), 3.seconds)
 
@@ -136,7 +139,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
         None,
         None,
         None,
-        None
+        None,
+        UUID.randomUUID().toString
       )
       val result = Try { Await.result(toTest.handleArchivehunterValidation(incomingRecord), 3.seconds) }
 

--- a/online_archive/src/test/scala/OwnMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/OwnMessageProcessorSpec.scala
@@ -159,7 +159,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       val req = RevalidateArchiveHunterRequest(recordIds)
 
       val records = recordIds.map(id=>{
-        val rec = ArchivedRecord(s"abcde$id",s"/path/to/file$id",1234L, "somebucket",s"file$id", None)
+        val rec = ArchivedRecord(s"abcde$id",s"/path/to/file$id",1234L, "somebucket",s"file$id", None, "corrId")
         rec.copy(id=Some(id))
       })
 
@@ -209,7 +209,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       val req = RevalidateArchiveHunterRequest(recordIds)
 
       val records = recordIds.map(id=>{
-        val rec = ArchivedRecord(s"abcde$id",s"/path/to/file$id",1234L, "somebucket",s"file$id", None)
+        val rec = ArchivedRecord(s"abcde$id",s"/path/to/file$id",1234L, "somebucket",s"file$id", None, "corrId")
         rec.copy(id=Some(id))
       })
 
@@ -272,7 +272,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       vidispineFunctions.uploadShapeIfRequired(any,any,org.mockito.ArgumentMatchers.eq("lowres"), any) answers((args:Array[AnyRef])=>Future(Right(MessageProcessorReturnValue(args(3).asInstanceOf[ArchivedRecord].asJson))))
       vidispineFunctions.uploadMetadataToS3(any,any,any) answers((args:Array[AnyRef])=>Future(Right(args(2).asInstanceOf[ArchivedRecord].asJson)))
 
-      val rec = ArchivedRecord("abcdefg","/path/to/original.file", 1234L, "somebucket", "uploaded/file", Some(1)).copy(id=Some(1234),vidispineItemId = Some("VX-33"))
+      val rec = ArchivedRecord("abcdefg","/path/to/original.file", 1234L, "somebucket", "uploaded/file", Some(1), "corrId").copy(id=Some(1234),vidispineItemId = Some("VX-33"))
       val toTest = new OwnMessageProcessor()
       val result = Await.result(toTest.uploadVidispineBits("VX-33", rec), 2.seconds)
 
@@ -307,7 +307,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       vidispineFunctions.uploadShapeIfRequired(any,any,org.mockito.ArgumentMatchers.eq("lowres"), any) answers((args:Array[AnyRef])=>Future(Right(MessageProcessorReturnValue(args(3).asInstanceOf[ArchivedRecord].asJson))))
       vidispineFunctions.uploadMetadataToS3(any,any,any) answers((args:Array[AnyRef])=>Future(Right(args(2).asInstanceOf[ArchivedRecord].asJson)))
 
-      val rec = ArchivedRecord("abcdefg","/path/to/original.file", 1234L, "somebucket", "uploaded/file", Some(1)).copy(id=Some(1234),vidispineItemId = Some("VX-33"))
+      val rec = ArchivedRecord("abcdefg","/path/to/original.file", 1234L, "somebucket", "uploaded/file", Some(1), "corrId").copy(id=Some(1234),vidispineItemId = Some("VX-33"))
       val toTest = new OwnMessageProcessor()
       val result = Try { Await.result(toTest.uploadVidispineBits("VX-33", rec), 2.seconds) }
       result must beAFailedTry
@@ -319,7 +319,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
 
   "OwnMessageProcessor.handleReplayStageTwo" should {
     "take an asset sweeper record, look up the corresponding ArchivedRecord (created by stage one) and call uploadVidispineBits then silently drop the message" in {
-      val archivedRecord = ArchivedRecord("abcdefg","/path/to/original.file", 12345L, "some-bucket","uploaded/original.file", Some(1))
+      val archivedRecord = ArchivedRecord("abcdefg","/path/to/original.file", 12345L, "some-bucket","uploaded/original.file", Some(1), "corrId")
       implicit val mat:Materializer = mock[Materializer]
       implicit val system:ActorSystem = mock[ActorSystem]
       implicit val archivedRecordDAO = mock[ArchivedRecordDAO]
@@ -407,7 +407,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
     }
 
     "not hide an error in the upload function" in {
-      val archivedRecord = ArchivedRecord("abcdefg","/path/to/original.file", 12345L, "some-bucket","uploaded/original.file", Some(1))
+      val archivedRecord = ArchivedRecord("abcdefg","/path/to/original.file", 12345L, "some-bucket","uploaded/original.file", Some(1), "corrId")
       implicit val mat:Materializer = mock[Materializer]
       implicit val system:ActorSystem = mock[ActorSystem]
       implicit val archivedRecordDAO = mock[ArchivedRecordDAO]
@@ -454,7 +454,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
     }
 
     "return a retryable failure if the validation fails" in {
-      val archivedRecord = ArchivedRecord("abcdefg","/path/to/original.file", 12345L, "some-bucket","uploaded/original.file", Some(1))
+      val archivedRecord = ArchivedRecord("abcdefg","/path/to/original.file", 12345L, "some-bucket","uploaded/original.file", Some(1), "corrId")
       implicit val mat:Materializer = mock[Materializer]
       implicit val system:ActorSystem = mock[ActorSystem]
       implicit val archivedRecordDAO = mock[ArchivedRecordDAO]

--- a/online_archive/src/test/scala/VidispineFunctionsSpec.scala
+++ b/online_archive/src/test/scala/VidispineFunctionsSpec.scala
@@ -53,7 +53,8 @@ class VidispineFunctionsSpec extends Specification with Mockito {
         originalFileSize=12345,
         uploadedBucket="bucket",
         uploadedPath="uploaded/path",
-        uploadedVersion=Some(4)
+        uploadedVersion=Some(4),
+        "corrId"
       ).copy(archiveHunterIDValidated = true)
       archivedRecordDAO.findBySourceFilename(any) returns Future(Some(record))
 
@@ -76,7 +77,8 @@ class VidispineFunctionsSpec extends Specification with Mockito {
           123456L,
           "some-bucket",
           "path/to/uploaded/file.mxf",
-          None
+          None,
+          "corrId"
         )
         val testProxy = VSShapeFile(
           "VX-1234",
@@ -98,7 +100,8 @@ class VidispineFunctionsSpec extends Specification with Mockito {
           123456L,
           "some-bucket",
           "path/to/uploaded/file.mxf",
-          None
+          None,
+          "corrId"
         )
         val testProxy = VSShapeFile(
           "VX-1234",
@@ -119,7 +122,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
   "VidispineFunctions.uploadShapeIfRequired" should {
     "stream the file content, tell ArchiveHunter to update its proxy and then update the datastore record" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, "corrId")
           .copy(archiveHunterIDValidated = true)
 
       val mockedInputStream = mock[InputStream]
@@ -180,7 +183,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
 
     "return Left if there is no file data available in Vidispine" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, "corrId")
           .copy(archiveHunterIDValidated = true)
 
       val mockedInputStream = mock[InputStream]
@@ -227,7 +230,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
 
     "return a failed Future if there is no such shape on the item" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, "corrId")
           .copy(archiveHunterIDValidated = true)
 
       val mockedInputStream = mock[InputStream]
@@ -262,7 +265,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
 
     "not stream the file content but return Right if the shape tag is not recognised" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, "corrId")
           .copy(archiveHunterIDValidated = true)
 
       val mockedInputStream = mock[InputStream]
@@ -320,7 +323,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
 
     "return Left if the upload fails" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, "corrId")
           .copy(archiveHunterIDValidated = true)
 
       val mockedInputStream = mock[InputStream]

--- a/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -25,6 +25,7 @@ import scala.concurrent.duration.DurationInt
 import scala.util.{Success, Try}
 import java.io.InputStream
 import java.time.ZonedDateTime
+import java.util.UUID
 
 class VidispineMessageProcessorSpec extends Specification with Mockito {
   val fakeDeliverablesConfig = PlutoDeliverablesConfig("Deliverables/",1)
@@ -132,7 +133,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
   "VidispineMessageProcessor.handleShapeUpdate" should {
     "call out to uploadShapeIfRequired provided that the shape should be pushed" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, UUID.randomUUID().toString)
           .copy(archiveHunterIDValidated = true)
 
       implicit val mockArchivedRecordDAO = mock[ArchivedRecordDAO]
@@ -163,7 +164,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
 
     "not call out to uploadShapeIfRequired and return Left if the ArchiveHunter ID is not validated yes" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, UUID.randomUUID().toString)
           .copy(archiveHunterIDValidated = false)
       implicit val mockArchivedRecordDAO = mock[ArchivedRecordDAO]
       mockArchivedRecordDAO.findByVidispineId(any) returns Future(Some(mockArchivedRecord))
@@ -192,7 +193,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
 
     "not call out to uploadShapeIfRequired and return Right if the file should be ignored" in {
       val mockArchivedRecord =
-        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None)
+        ArchivedRecord("abcdefg","/path/to/original/file",123456L, "some-bucket", "path/to/uploaded/file", None, UUID.randomUUID().toString)
           .copy(archiveHunterIDValidated = true)
       val mockIgnoredRecord = IgnoredRecord(None,"/path/to/original/file", "test", Some("VX-123"), None)
 

--- a/online_nearline/src/main/resources/logback.xml
+++ b/online_nearline/src/main/resources/logback.xml
@@ -2,7 +2,7 @@
 
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZ} [%thread] [%X{msgId};%X{retryAttempt};%X{routingKey};%X{exchange};%X{isRedeliver}] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{yyyy-MM-dd'T'HH:mm:ss.SSSZZ} [%thread] [%X{msgId};%X{retryAttempt};%X{routingKey};%X{exchange};%X{isRedeliver};%X{correlationId}] %-5level %logger{36} - %msg%n</pattern>
         </encoder>
     </appender>
 

--- a/online_nearline/src/main/scala/AssetSweeperMessageProcessor.scala
+++ b/online_nearline/src/main/scala/AssetSweeperMessageProcessor.scala
@@ -12,9 +12,10 @@ import io.circe.Json
 import io.circe.generic.auto._
 import io.circe.syntax._
 import matrixstore.MatrixStoreConfig
-import org.slf4j.LoggerFactory
+import org.slf4j.{LoggerFactory, MDC}
 
 import java.nio.file.{Files, Paths}
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 
 class AssetSweeperMessageProcessor()
@@ -38,8 +39,10 @@ class AssetSweeperMessageProcessor()
         case Right(objectId) =>
           val record = maybeNearlineRecord match {
             case Some(rec) => rec
-            case None => NearlineRecord(objectId, fullPath.toString)
+            case None => NearlineRecord(objectId, fullPath.toString, UUID.randomUUID().toString)
           }
+
+          MDC.put("correlationId", record.correlationId)
 
           nearlineRecordDAO
             .writeRecord(record)

--- a/online_nearline/src/main/scala/AssetSweeperMessageProcessor.scala
+++ b/online_nearline/src/main/scala/AssetSweeperMessageProcessor.scala
@@ -31,6 +31,8 @@ class AssetSweeperMessageProcessor()
   private val logger = LoggerFactory.getLogger(getClass)
   import AssetSweeperNewFile.Codec._
 
+  protected def newCorrelationId: String = UUID.randomUUID().toString
+
   def copyFile(vault: Vault, file: AssetSweeperNewFile, maybeNearlineRecord: Option[NearlineRecord]): Future[Either[String, Json]] = {
     val fullPath = Paths.get(file.filepath, file.filename)
 
@@ -39,7 +41,7 @@ class AssetSweeperMessageProcessor()
         case Right(objectId) =>
           val record = maybeNearlineRecord match {
             case Some(rec) => rec
-            case None => NearlineRecord(objectId, fullPath.toString, UUID.randomUUID().toString)
+            case None => NearlineRecord(objectId, fullPath.toString, newCorrelationId)
           }
 
           MDC.put("correlationId", record.correlationId)
@@ -103,6 +105,7 @@ class AssetSweeperMessageProcessor()
         val newRec = NearlineRecord(
           objectId=matchingNearlineFiles.head.oid,
           originalFilePath = filePath.toString,
+          correlationId = newCorrelationId
         )
 
         val updatedRec = maybeVidispineMatches.flatMap(_.file.headOption).flatMap(_.item.map(_.id)) match {

--- a/online_nearline/src/test/scala/AssetSweeperMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/AssetSweeperMessageProcessorSpec.scala
@@ -12,6 +12,7 @@ import io.circe.syntax._
 import io.circe.generic.auto._
 
 import java.io.IOException
+import java.util.UUID
 import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 import scala.concurrent.{Await, Future}
@@ -56,7 +57,8 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         vidispineItemId = None,
         vidispineVersionId = None,
         proxyObjectId = None,
-        metadataXMLObjectId = None
+        metadataXMLObjectId = None,
+        correlationId = UUID.randomUUID().toString
       )
 
       result.map(value=>value) must beRight(rec.asJson)
@@ -74,7 +76,8 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         vidispineItemId = None,
         vidispineVersionId = None,
         proxyObjectId = None,
-        metadataXMLObjectId = None
+        metadataXMLObjectId = None,
+        correlationId = UUID.randomUUID().toString
       )
       nearlineRecordDAO.writeRecord(any) returns Future(123)
       nearlineRecordDAO.findBySourceFilename(any) returns Future(Some(rec))
@@ -158,7 +161,8 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         vidispineItemId = None,
         vidispineVersionId = None,
         proxyObjectId = None,
-        metadataXMLObjectId = None
+        metadataXMLObjectId = None,
+        correlationId = UUID.randomUUID().toString
       )
       nearlineRecordDAO.writeRecord(any) returns Future(123)
       nearlineRecordDAO.findBySourceFilename(any) returns Future(Some(rec))

--- a/online_nearline/src/test/scala/AssetSweeperMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/AssetSweeperMessageProcessorSpec.scala
@@ -42,6 +42,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
       mockVault.getObject(any) returns mockObject
 
       val toTest = new AssetSweeperMessageProcessor() {
+        override protected def newCorrelationId: String = "E2C460D9-9BC5-4A84-866C-0380BF143579"
         override protected def checkForPreExistingFiles(vault: Vault, file: AssetSweeperNewFile): Future[Option[NearlineRecord]] = mockCheckForPreExistingFiles(vault, file)
       }
       val mockFile = mock[AssetSweeperNewFile]
@@ -58,7 +59,7 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         vidispineVersionId = None,
         proxyObjectId = None,
         metadataXMLObjectId = None,
-        correlationId = UUID.randomUUID().toString
+        correlationId = "E2C460D9-9BC5-4A84-866C-0380BF143579"
       )
 
       result.map(value=>value) must beRight(rec.asJson)
@@ -116,7 +117,8 @@ class AssetSweeperMessageProcessorSpec extends Specification with Mockito {
         vidispineItemId = None,
         vidispineVersionId = None,
         proxyObjectId = None,
-        metadataXMLObjectId = None
+        metadataXMLObjectId = None,
+        correlationId = "corrId"
       )
       nearlineRecordDAO.writeRecord(any) returns Future(123)
       nearlineRecordDAO.findBySourceFilename(any) returns Future(None)

--- a/online_nearline/src/test/scala/OwnMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/OwnMessageProcessorSpec.scala
@@ -31,7 +31,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
 
       val rec = NearlineRecord(
         "some-object-id",
-        "/path/to/Assets/project/original-file.mov"
+        "/path/to/Assets/project/original-file.mov",
+        "corrId"
       )
       val fakeProject = mock[ProjectRecord]
       fakeProject.id returns Some(1234)
@@ -98,7 +99,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
 
       val rec = NearlineRecord(
         "some-object-id",
-        "/path/to/Assets/project/original-file.mov"
+        "/path/to/Assets/project/original-file.mov",
+        "corrId"
       )
       val fakeProject = mock[ProjectRecord]
       fakeProject.id returns Some(1234)
@@ -165,7 +167,8 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
 
       val rec = NearlineRecord(
         "some-object-id",
-        "/path/to/Assets/project/original-file.mov"
+        "/path/to/Assets/project/original-file.mov",
+        "corrId"
       )
       val fakeProject = mock[ProjectRecord]
       fakeProject.id returns Some(1234)
@@ -211,12 +214,12 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       implicit val vsCommunicator = mock[VidispineCommunicator]
       vsCommunicator.setGroupedMetadataValue(any, any,any,any) returns Future(Some(mock[ItemResponseSimplified]))
       implicit val nearlineRecordDAO = mock[NearlineRecordDAO]
-      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234), vidispineItemId = Some("VX-123"), vidispineVersionId=Some(1))
+      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234), vidispineItemId = Some("VX-123"), vidispineVersionId=Some(1))
       nearlineRecordDAO.getRecord(any) returns Future(Some(fakeRecord))
       val asLookup = mock[AssetFolderLookup]
 
       val toTest = new OwnMessageProcessor(mxsConfig, asLookup, "own-exchange-name")
-      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234)).asJson), 2.seconds)
+      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234)).asJson), 2.seconds)
 
       there was one(nearlineRecordDAO).getRecord(1234)
       there was one(vsCommunicator).setGroupedMetadataValue("VX-123", "Asset", "gnm_nearline_id","some-object-id")
@@ -230,12 +233,12 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       implicit val vsCommunicator = mock[VidispineCommunicator]
       vsCommunicator.setGroupedMetadataValue(any,any,any,any) returns Future.failed(new RuntimeException("something broke"))
       implicit val nearlineRecordDAO = mock[NearlineRecordDAO]
-      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234), vidispineItemId = Some("VX-123"), vidispineVersionId=Some(1))
+      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234), vidispineItemId = Some("VX-123"), vidispineVersionId=Some(1))
       nearlineRecordDAO.getRecord(any) returns Future(Some(fakeRecord))
       val asLookup = mock[AssetFolderLookup]
 
       val toTest = new OwnMessageProcessor(mxsConfig, asLookup, "own-exchange-name")
-      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234)).asJson), 2.seconds)
+      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234)).asJson), 2.seconds)
 
       there was one(nearlineRecordDAO).getRecord(1234)
       there was one(vsCommunicator).setGroupedMetadataValue("VX-123", "Asset","gnm_nearline_id","some-object-id")
@@ -249,12 +252,12 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       implicit val vsCommunicator = mock[VidispineCommunicator]
       vsCommunicator.setGroupedMetadataValue(any, any,any,any) returns Future(None)
       implicit val nearlineRecordDAO = mock[NearlineRecordDAO]
-      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234), vidispineItemId = Some("VX-123"), vidispineVersionId=Some(1))
+      val fakeRecord = NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234), vidispineItemId = Some("VX-123"), vidispineVersionId=Some(1))
       nearlineRecordDAO.getRecord(any) returns Future(Some(fakeRecord))
       val asLookup = mock[AssetFolderLookup]
 
       val toTest = new OwnMessageProcessor(mxsConfig, asLookup, "own-exchange-name")
-      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234)).asJson), 2.seconds)
+      val result = Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234)).asJson), 2.seconds)
 
       there was one(nearlineRecordDAO).getRecord(1234)
       there was one(vsCommunicator).setGroupedMetadataValue("VX-123", "Asset", "gnm_nearline_id","some-object-id")
@@ -275,7 +278,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       val asLookup = mock[AssetFolderLookup]
 
       val toTest = new OwnMessageProcessor(mxsConfig, asLookup, "own-exchange-name")
-      val result = Try { Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file").copy(id=Some(1234)).asJson), 2.seconds) }
+      val result = Try { Await.result(toTest.handleSuccessfulMetadataWrite(NearlineRecord("some-object-id","/path/to/original/file", "corrId").copy(id=Some(1234)).asJson), 2.seconds) }
 
       there was one(nearlineRecordDAO).getRecord(1234)
       there was no(vsCommunicator).setGroupedMetadataValue(any,any,any,any)
@@ -299,7 +302,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
 
       implicit val vsCommunicator = mock[VidispineCommunicator]
 
-      val rec = NearlineRecord("source-object-id","/path/to/original-file").copy(id=Some(1234))
+      val rec = NearlineRecord("source-object-id","/path/to/original-file", "corrId").copy(id=Some(1234))
       implicit val nearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.setInternallyArchived(any,any) returns Future(Some(rec.copy(internallyArchived = Some(true))))
       val asLookup = mock[AssetFolderLookup]
@@ -316,7 +319,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
       val result = Await.result(toTest.handleInternalArchiveRequested(rec.asJson), 2.seconds)
 
       result must beRight
-      result.flatMap(_.content.as[NearlineRecord]) must beRight(NearlineRecord("source-object-id","/path/to/original-file").copy(id=Some(1234), internallyArchived = Some(true)))
+      result.flatMap(_.content.as[NearlineRecord]) must beRight(NearlineRecord("source-object-id","/path/to/original-file", "corrId").copy(id=Some(1234), internallyArchived = Some(true)))
       there was one(mockCrossCopy).apply(mockSourceVault, "source-object-id", mockDestVault)
       there was one(mxsConnectionBuilder).withVaultsFuture(org.mockito.ArgumentMatchers.eq(Seq("vault-id", "internal-archive-vault")))(any)(any)
       there was one(nearlineRecordDAO).setInternallyArchived(1234, true)
@@ -337,7 +340,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
 
       implicit val vsCommunicator = mock[VidispineCommunicator]
 
-      val rec = NearlineRecord("source-object-id","/path/to/original-file").copy(id=Some(1234))
+      val rec = NearlineRecord("source-object-id","/path/to/original-file", "corrId").copy(id=Some(1234))
       implicit val nearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.setInternallyArchived(any,any) returns Future(Some(rec.copy(internallyArchived = Some(true))))
       val asLookup = mock[AssetFolderLookup]
@@ -385,7 +388,7 @@ class OwnMessageProcessorSpec extends Specification with Mockito {
         override def isCopyNeeded(nearlineVault: Vault, destVault: Vault, rec: NearlineRecord): Future[Boolean] = Future(true)
       }
 
-      val rec = NearlineRecord("source-object-id","/path/to/original-file").copy(id=Some(1234))
+      val rec = NearlineRecord("source-object-id","/path/to/original-file", "corrId").copy(id=Some(1234))
       val result = Await.result(toTest.handleInternalArchiveRequested(rec.asJson), 2.seconds)
 
       result must beLeft("Kaboom")

--- a/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -121,7 +121,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -170,7 +173,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -218,7 +224,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -273,7 +282,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -342,7 +354,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
 
       val mockShape = mock[ShapeDocument]
@@ -427,7 +442,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -481,7 +499,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -549,7 +570,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -616,7 +640,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -695,7 +722,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -744,7 +774,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -787,7 +820,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -833,7 +869,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -879,7 +918,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-12345"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -922,7 +964,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -966,7 +1011,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1031,7 +1079,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1078,7 +1129,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1129,7 +1183,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1206,7 +1263,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1267,7 +1327,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1358,7 +1421,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1389,7 +1455,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)
@@ -1437,7 +1506,10 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("VX-123"),
         None,
         None,
-        None
+        None,
+        None,
+        false,
+        "corrId"
       )
       implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
       nearlineRecordDAO.writeRecord(any) returns Future(123)


### PR DESCRIPTION
## What does this change?

Adds a "correlation ID" to the logs. This links different messages that relate to the same piece of content

## How to test

Run the updated software. You should see an extra UUID in the log-lines, as the last parameter in the square-brackets.
Update Logstash to ingest this value as a field and you'll be able to filter on it

## How can we measure success?

Easier to see what is happening with problematic items
