### PR TITLE
SilentDrop vidispine failures instead of DLQ'ing them

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/nearline_archive/NearlineRecord.scala
@@ -35,7 +35,7 @@ class NearlineRecordRow (tag:Tag) extends Table[NearlineRecord](tag, "nearlinear
   def metadataXMLObjectId = column[Option[String]]("s_metadata_xml_objectid")
   def internallyArchived = column[Option[Boolean]]("b_internally_archived")
   def expectingVidispineId = column[Boolean]("b_expecting_vidispine_id")
-  def correlationId = column[String]("s_correlation_id")
+  def correlationId = column[Option[String]]("s_correlation_id")
 
-  def * = (id.?, objectId, originalFilePath, vidispineItemId, vidispineVersionId, proxyObjectId, metadataXMLObjectId, internallyArchived, expectingVidispineId, correlationId) <> (NearlineRecord.tupled, NearlineRecord.unapply)
+  def * = (id.?, objectId, originalFilePath, vidispineItemId, vidispineVersionId, proxyObjectId, metadataXMLObjectId, internallyArchived, expectingVidispineId, correlationId.getOrElse("<absent>")) <> (NearlineRecord.tupled, NearlineRecord.unapply)
 }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecord.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/online_archive/ArchivedRecord.scala
@@ -57,12 +57,12 @@ class ArchivedRecordRow (tag:Tag) extends Table[ArchivedRecord](tag, "onlinearch
   def proxyVersion = column[Option[Int]]("i_proxy_version")
   def metadataXML = column[Option[String]]("s_metadata_xml_path")
   def metadataVersion = column[Option[Int]]("i_metadata_version")
-  def correlationId = column[String]("s_correlation_id")
+  def correlationId = column[Option[String]]("s_correlation_id")
 
   def filepathIdx = index("filepath_idx", originalFilePath)
   def archiveHunterIdIds = index("archivehunter_id_idx", archiveHunterID, unique = true)
   def vidispineIdIdx = index("vidispine_item_idx", vidispineItemId)
 
   def * = (id.?, archiveHunterID, archiveHunterIDValidated, originalFilePath, originalFileSize, uploadedBucket, uploadedPath,
-    uploadedVersion, vidispineItemId, vidispineVersionId, proxyBucket, proxyPath, proxyVersion, metadataXML, metadataVersion, correlationId) <> (ArchivedRecord.tupled, ArchivedRecord.unapply)
+    uploadedVersion, vidispineItemId, vidispineVersionId, proxyBucket, proxyPath, proxyVersion, metadataXML, metadataVersion, correlationId.getOrElse("<absent>")) <> (ArchivedRecord.tupled, ArchivedRecord.unapply)
 }

--- a/online_archive/src/main/scala/VidispineMessageProcessor.scala
+++ b/online_archive/src/main/scala/VidispineMessageProcessor.scala
@@ -152,7 +152,7 @@ class VidispineMessageProcessor(plutoCoreConfig: PlutoCoreConfig, deliverablesCo
     logger.debug(s"Received message content $mediaIngested")
     if (status.contains("FAILED") || itemId.isEmpty) {
       logger.error(s"Import status not in correct state for archive $status itemId=${itemId}")
-      Future.failed(new RuntimeException(s"Import status not in correct state for archive $status itemId=$itemId"))
+      Future.failed(SilentDropMessage(Some(s"Import status not in correct state for archive $status itemId=$itemId")))
     } else {
       mediaIngested.itemId match {
         case Some(itemId)=> //unfortunately we can't accurately determine the _original_ file from an essence_version message so we need to go back to the item

--- a/online_nearline/src/main/scala/VidispineMessageProcessor.scala
+++ b/online_nearline/src/main/scala/VidispineMessageProcessor.scala
@@ -216,8 +216,8 @@ class VidispineMessageProcessor()
 
     logger.debug(s"Received message content $mediaIngested")
     if (status.contains("FAILED") || itemId.isEmpty) {
-      logger.error(s"Import status not in correct state for archive $status itemId=${itemId}")
-      Future.failed(new RuntimeException(s"Import status not in correct state for archive $status itemId=${itemId}"))
+      logger.error(s"Import status not in correct state for archive $status itemId=$itemId")
+      Future.failed(SilentDropMessage(Some(s"Import status not in correct state for archive $status itemId=$itemId")))
     } else {
       mediaIngested.sourceOrDestFileId match {
         case Some(fileId)=>


### PR DESCRIPTION
## What does this change?

Fixes https://codemill.atlassian.net/browse/GP-820.
Applies `SilentDropMessage` if a Vidispine update is received indicating a failure. This is to prevent spurious alerts and DLQ clogging.

## How to test

Monitor logs for the error messge `Import status not in correct state`. It should be reported as a SilentDrop and not cause pagerduty alerts any more.

## How can we measure success?

Less alert noise

## Have we considered potential risks?

We need to be alert to the root causes of import failures still, and this will make them a bit less visible
