### PR TITLE
GP-780 Extract getProjectMetadata method from assetFolderProjectLookup

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/plutocore/AssetFolderLookup.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/plutocore/AssetFolderLookup.scala
@@ -167,11 +167,15 @@ class AssetFolderLookup (config:PlutoCoreConfig)(implicit mat:Materializer, acto
 
     assetFolderRecordLookup(forFile)
       .flatMap(
-        _.map(record=>{
-          val req = HttpRequest(uri = s"${config.baseUri}/api/project/${record.project}")
-          callToPluto[ProjectRecord](req)
-        }).sequence.map(_.flatten) //.sequence here is a bit of cats "magic" that turns the Option[Future[Option]] into a Future[Option[Option]]
+        _.map(record => getProjectMetadata(record.project)
+        ).sequence.map(_.flatten) //.sequence here is a bit of cats "magic" that turns the Option[Future[Option]] into a Future[Option[Option]]
       )
+  }
+
+  def getProjectMetadata(projectId: String) = {
+    import ProjectRecordEncoder._
+    val req = HttpRequest(uri = s"${config.baseUri}/api/project/$projectId")
+    callToPluto[ProjectRecord](req)
   }
 
   def commissionLookup(commissionId:Int) = {


### PR DESCRIPTION
## What does this change?
Extract getting project metadata into a separate method. Useful when we already know the `projectId`, e.g. when `media_remover` needs to check the project(s) of a media item.
<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images
N/A
<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility
N/A

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

