### PR TITLE
Make handleUpdateMessage differentiate between statuses, not-req-msg …

### DIFF
--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -3,7 +3,7 @@ import akka.stream.Materializer
 import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.gu.multimedia.mxscopy.MXSConnectionBuilder
 import com.gu.multimedia.mxscopy.streamcomponents.OMFastContentSearchSource
-import com.gu.multimedia.storagetier.framework.{MessageProcessingFramework, MessageProcessor, MessageProcessorConverters, MessageProcessorReturnValue}
+import com.gu.multimedia.storagetier.framework._
 import com.gu.multimedia.storagetier.vidispine.VidispineCommunicator
 import com.om.mxs.client.japi.Vault
 import io.circe.Json
@@ -22,6 +22,8 @@ class PlutoCoreMessageProcessor(mxsConfig:MatrixStoreConfig)(implicit mat:Materi
                                                              vidispineCommunicator: VidispineCommunicator,
                                                              ec:ExecutionContext) extends MessageProcessor {
   private val logger = LoggerFactory.getLogger(getClass)
+
+  private val statusesMediaNotRequired = List("held", "completed", "killed") // Could we use com.gu.multimedia.storagetier.plutocore.EntryStatus as source here. Are those the canonical states?
 
   def searchAssociatedOnlineMedia(projectId: Int, vidispineCommunicator: VidispineCommunicator): Future[Seq[OnlineOutputMessage]] = {
     onlineFilesByProject(vidispineCommunicator, projectId)
@@ -57,34 +59,38 @@ class PlutoCoreMessageProcessor(mxsConfig:MatrixStoreConfig)(implicit mat:Materi
     searchAssociatedOnlineMedia(projectId, vidispineCommunicator).map(Right.apply)
   }
 
-  def handleStatusMessage(updateMessage: ProjectUpdateMessage, routingKey: String, framework: MessageProcessingFramework): Future[Either[String, MessageProcessorReturnValue]] = {
-    Future.sequence(Seq(getNearlineResults(updateMessage.id), getOnlineResults(updateMessage.id))).map(allResults => {
-      (allResults.head, allResults(1)) match {
-        case (Right(nearlineResults), Right(onlineResults)) =>
-          if (nearlineResults.length < 10000 && onlineResults.length < 10000) {
-            logger.info(s"About to send bulk messages for ${nearlineResults.length} nearline results")
-            framework.bulkSendMessages(routingKey, nearlineResults)
-            logger.info(s"About to send bulk messages for ${onlineResults.length} online results")
-            framework.bulkSendMessages(routingKey, onlineResults)
-            logger.info(s"Bulk messages sent; about to send the RestorerSummaryMessage for project ${updateMessage.id}")
-            val msg = RestorerSummaryMessage(updateMessage.id, ZonedDateTime.now(), updateMessage.status, numberOfAssociatedFilesNearline = nearlineResults.length, numberOfAssociatedFilesOnline = onlineResults.length)
-            Right(MessageProcessorConverters.contentToMPRV(msg.asJson))
-          } else {
-            throw new RuntimeException(s"Too many files attached to project ${updateMessage.id}, nearlineResults = ${nearlineResults.length}, onlineResults = ${onlineResults.length}")
+
+  def handleUpdateMessage(updateMessage: ProjectUpdateMessage, routingKey: String, framework: MessageProcessingFramework): Future[Either[String, MessageProcessorReturnValue]] =
+    updateMessage.status match {
+      case status if statusesMediaNotRequired.contains(status.toLowerCase)  =>
+        Future.sequence(Seq(getNearlineResults(updateMessage.id), getOnlineResults(updateMessage.id))).map(allResults => {
+          (allResults.head, allResults(1)) match {
+            case (Right(nearlineResults), Right(onlineResults)) =>
+              if (nearlineResults.length < 10000 && onlineResults.length < 10000) {
+                logger.info(s"About to send bulk messages for ${nearlineResults.length} nearline results")
+                framework.bulkSendMessages(routingKey, nearlineResults)
+                logger.info(s"About to send bulk messages for ${onlineResults.length} online results")
+                framework.bulkSendMessages(routingKey, onlineResults)
+                logger.info(s"Bulk messages sent; about to send the RestorerSummaryMessage for project ${updateMessage.id}")
+                val msg = RestorerSummaryMessage(updateMessage.id, ZonedDateTime.now(), updateMessage.status, numberOfAssociatedFilesNearline = nearlineResults.length, numberOfAssociatedFilesOnline = onlineResults.length)
+                Right(MessageProcessorConverters.contentToMPRV(msg.asJson))
+              } else {
+                throw new RuntimeException(s"Too many files attached to project ${updateMessage.id}, nearlineResults = ${nearlineResults.length}, onlineResults = ${onlineResults.length}")
+              }
+            case (Left(nearlineErr), _) =>
+              logger.error(s"Could not connect to Matrix store: $nearlineErr")
+              Left(nearlineErr)
+            case (_, Left(onlineErr)) =>
+              logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
+              Left(onlineErr)
+            case (Left(nearlineErr), Left(onlineErr)) =>
+              logger.error(s"Could not connect to Matrix store: $nearlineErr")
+              logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
+              Left(s"nearlineErr: $nearlineErr; onlineErr: $onlineErr")
           }
-        case (Left(nearlineErr), _)=>
-          logger.error(s"Could not connect to Matrix store: $nearlineErr")
-          Left(nearlineErr)
-        case (_, Left(onlineErr))=>
-          logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
-          Left(onlineErr)
-        case (Left(nearlineErr), Left(onlineErr))=>
-          logger.error(s"Could not connect to Matrix store: $nearlineErr")
-          logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
-          Left(s"nearlineErr: $nearlineErr; onlineErr: $onlineErr")
-      }
-    })
-  }
+        })
+      case _ => Future.failed(SilentDropMessage(Some(s"Incoming project update message has a status we don't care about (${updateMessage.status}), dropping it.")))
+    }
 
   /**
    * Override this method in your subclass to handle an incoming message
@@ -105,7 +111,7 @@ class PlutoCoreMessageProcessor(mxsConfig:MatrixStoreConfig)(implicit mat:Materi
             Future.failed(new RuntimeException(s"Could not unmarshal json message ${msg.noSpaces} into an ProjectUpdate: $err"))
           case Right(updateMessage) =>
             logger.info(s"here is an update status ${updateMessage.status}")
-            handleStatusMessage(updateMessage, routingKey, msgProcessingFramework)
+            handleUpdateMessage(updateMessage, routingKey, msgProcessingFramework)
         }
       case _ =>
         logger.warn(s"Dropping message $routingKey from own exchange as I don't know how to handle it. This should be fixed in the code.")

--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -4,6 +4,7 @@ import akka.stream.scaladsl.{Keep, Sink, Source}
 import com.gu.multimedia.mxscopy.MXSConnectionBuilder
 import com.gu.multimedia.mxscopy.streamcomponents.OMFastContentSearchSource
 import com.gu.multimedia.storagetier.framework._
+import com.gu.multimedia.storagetier.plutocore.EntryStatus
 import com.gu.multimedia.storagetier.vidispine.VidispineCommunicator
 import com.om.mxs.client.japi.Vault
 import io.circe.Json
@@ -23,7 +24,7 @@ class PlutoCoreMessageProcessor(mxsConfig:MatrixStoreConfig)(implicit mat:Materi
                                                              ec:ExecutionContext) extends MessageProcessor {
   private val logger = LoggerFactory.getLogger(getClass)
 
-  private val statusesMediaNotRequired = List("held", "completed", "killed") // Could we use com.gu.multimedia.storagetier.plutocore.EntryStatus as source here. Are those the canonical states?
+  private val statusesMediaNotRequired = List(EntryStatus.Held.toString, EntryStatus.Completed.toString, EntryStatus.Killed.toString)
 
   def searchAssociatedOnlineMedia(projectId: Int, vidispineCommunicator: VidispineCommunicator): Future[Seq[OnlineOutputMessage]] = {
     onlineFilesByProject(vidispineCommunicator, projectId)
@@ -59,38 +60,41 @@ class PlutoCoreMessageProcessor(mxsConfig:MatrixStoreConfig)(implicit mat:Materi
     searchAssociatedOnlineMedia(projectId, vidispineCommunicator).map(Right.apply)
   }
 
-
   def handleUpdateMessage(updateMessage: ProjectUpdateMessage, routingKey: String, framework: MessageProcessingFramework): Future[Either[String, MessageProcessorReturnValue]] =
     updateMessage.status match {
-      case status if statusesMediaNotRequired.contains(status.toLowerCase)  =>
-        Future.sequence(Seq(getNearlineResults(updateMessage.id), getOnlineResults(updateMessage.id))).map(allResults => {
-          (allResults.head, allResults(1)) match {
-            case (Right(nearlineResults), Right(onlineResults)) =>
-              if (nearlineResults.length < 10000 && onlineResults.length < 10000) {
-                logger.info(s"About to send bulk messages for ${nearlineResults.length} nearline results")
-                framework.bulkSendMessages(routingKey, nearlineResults)
-                logger.info(s"About to send bulk messages for ${onlineResults.length} online results")
-                framework.bulkSendMessages(routingKey, onlineResults)
-                logger.info(s"Bulk messages sent; about to send the RestorerSummaryMessage for project ${updateMessage.id}")
-                val msg = RestorerSummaryMessage(updateMessage.id, ZonedDateTime.now(), updateMessage.status, numberOfAssociatedFilesNearline = nearlineResults.length, numberOfAssociatedFilesOnline = onlineResults.length)
-                Right(MessageProcessorConverters.contentToMPRV(msg.asJson))
-              } else {
-                throw new RuntimeException(s"Too many files attached to project ${updateMessage.id}, nearlineResults = ${nearlineResults.length}, onlineResults = ${onlineResults.length}")
-              }
-            case (Left(nearlineErr), _) =>
-              logger.error(s"Could not connect to Matrix store: $nearlineErr")
-              Left(nearlineErr)
-            case (_, Left(onlineErr)) =>
-              logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
-              Left(onlineErr)
-            case (Left(nearlineErr), Left(onlineErr)) =>
-              logger.error(s"Could not connect to Matrix store: $nearlineErr")
-              logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
-              Left(s"nearlineErr: $nearlineErr; onlineErr: $onlineErr")
-          }
-        })
+      case status if statusesMediaNotRequired.contains(status)  =>
+        Future.sequence(Seq(getNearlineResults(updateMessage.id), getOnlineResults(updateMessage.id)))
+          .map(allResults => processResults(allResults, routingKey, framework, updateMessage.id, updateMessage.status))
       case _ => Future.failed(SilentDropMessage(Some(s"Incoming project update message has a status we don't care about (${updateMessage.status}), dropping it.")))
     }
+
+  private def processResults(allResults: Seq[Either[String, Seq[OnlineOutputMessage]]], routingKey: String, framework: MessageProcessingFramework, projectId: Int, projectStatus: String) = (allResults.head, allResults(1)) match {
+    case (Right(nearlineResults), Right(onlineResults)) =>
+      if (nearlineResults.length < 10000 && onlineResults.length < 10000) {
+        logger.info(s"About to send bulk messages for ${nearlineResults.length} nearline results")
+        framework.bulkSendMessages(routingKey, nearlineResults)
+
+        logger.info(s"About to send bulk messages for ${onlineResults.length} online results")
+        framework.bulkSendMessages(routingKey, onlineResults)
+
+        logger.info(s"Bulk messages sent; about to send the RestorerSummaryMessage for project $projectId")
+        val msg = RestorerSummaryMessage(projectId, ZonedDateTime.now(), projectStatus, numberOfAssociatedFilesNearline = nearlineResults.length, numberOfAssociatedFilesOnline = onlineResults.length)
+
+        Right(MessageProcessorConverters.contentToMPRV(msg.asJson))
+      } else {
+        throw new RuntimeException(s"Too many files attached to project $projectId, nearlineResults = ${nearlineResults.length}, onlineResults = ${onlineResults.length}")
+      }
+    case (Left(nearlineErr), _) =>
+      logger.error(s"Could not connect to Matrix store for nearline results: $nearlineErr")
+      Left(nearlineErr)
+    case (_, Left(onlineErr)) =>
+      logger.error(s"Unexpected error from getOnlineResults: $onlineErr")
+      Left(onlineErr)
+    case (Left(nearlineErr), Left(onlineErr)) =>
+      logger.error(s"Could not connect to Matrix store for nearline results: $nearlineErr. ALSO, unexpected error from getOnlineResults: $onlineErr")
+      Left(s"nearlineErr: $nearlineErr; onlineErr: $onlineErr")
+  }
+
 
   /**
    * Override this method in your subclass to handle an incoming message

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorTest.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorTest.scala
@@ -108,14 +108,7 @@ class PlutoCoreMessageProcessorTest(implicit ec: ExecutionContext) extends Speci
     }
 
     "drop message in handleUpdateMessage if status is New" in {
-//      val nearlineResults = for(i <- 1 to 2) yield OnlineOutputMessage.apply(ObjectMatrixEntry(s"file$i", Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", 233).withValue("GNM_TYPE", "rushes")), None))
-//      val onlineResults = for (i <- 1 to 3) yield OnlineOutputMessage.apply(VSOnlineOutputMessage("ONLINE", 233, Some(s"p$i"), Some(s"VX-$i"), s"VX-${i + 1}", "Branding"))
-
       val toTest = new PlutoCoreMessageProcessor(mxsConfig)
-//       {
-//        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
-//        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(onlineResults)
-//      }
 
       val updateMessage = ProjectUpdateMessage(
         status = EntryStatus.New.toString,


### PR DESCRIPTION
…only for subset

- add list of statuses that should trigger Media Not Required messages
- rename `handleStatusMessage` to `handleUpdateMessage`
- add tests for new cases

## What does this change?

<!-- list out the headlines of what's going on -->
Instead of sending media not required-messages for any project update, now only sends them if the new project status is `Held`, `Completed`, or `Killed`

## Why is the change needed?

<!-- Prefer to copy-paste as not everyone may have access to Jira or Trello. References are ok in addition but please include enough context. -->
While the receiving Media Remover double checks that a file is really still deletable, it is very, very unnecessary to collect and send these messages for when they will be ignored anyways.

## Important implementation details

<!-- e.g. some novel algorithm, or explaining iteraction between multiple components -->

## Risks to consider when deploying

<!-- does this touch live data? Are there database migrations that would complicate a roll-back? Is it just generally scary? -->
