### PR TITLE
GP-823 Ensure that branding does not get deleted

### DIFF
--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -33,7 +33,7 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig)(implicit mat: Mate
 
   def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] =
     vidispineCommunicator.getFilesOfProject(projectId)
-      .map(_.filter(item => !isBranding(item)).map(item => InternalOnlineOutputMessage.toOnlineOutputMessage(item)))
+      .map(_.filterNot(isBranding).map(item => InternalOnlineOutputMessage.toOnlineOutputMessage(item)))
 
   // GP-823 Ensure that branding does not get deleted
   def isBranding(item: VSOnlineOutputMessage): Boolean = item.mediaCategory.toLowerCase match {
@@ -51,7 +51,7 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig)(implicit mat: Mate
       s"GNM_PROJECT_ID:\"$projectId\"",
       Array("MXFS_PATH", "MXFS_FILENAME", "GNM_PROJECT_ID", "GNM_TYPE", "__mxs__length")
     )
-    ).filter(entry => !isBranding(entry))
+    ).filterNot(isBranding)
       .map(entry => InternalOnlineOutputMessage.toOnlineOutputMessage(entry))
       .toMat(sinkFactory)(Keep.right)
       .run()

--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -74,10 +74,10 @@ class PlutoCoreMessageProcessor(mxsConfig:MatrixStoreConfig)(implicit mat:Materi
     case (Right(nearlineResults), Right(onlineResults)) =>
       if (nearlineResults.length < 10000 && onlineResults.length < 10000) {
         logger.info(s"About to send bulk messages for ${nearlineResults.length} nearline results")
-        framework.bulkSendMessages(routingKey, nearlineResults)
+        framework.bulkSendMessages(routingKey + ".nearline", nearlineResults)
 
         logger.info(s"About to send bulk messages for ${onlineResults.length} online results")
-        framework.bulkSendMessages(routingKey, onlineResults)
+        framework.bulkSendMessages(routingKey + ".online", onlineResults)
 
         logger.info(s"Bulk messages sent; about to send the RestorerSummaryMessage for project $projectId")
         val msg = RestorerSummaryMessage(projectId, ZonedDateTime.now(), projectStatus, numberOfAssociatedFilesNearline = nearlineResults.length, numberOfAssociatedFilesOnline = onlineResults.length)

--- a/project_restorer/src/main/scala/RoutingKeys.scala
+++ b/project_restorer/src/main/scala/RoutingKeys.scala
@@ -1,3 +1,3 @@
 object RoutingKeys {
-  val MediaNotRequired = "storagetier.media.notrequired"
+  val MediaNotRequired = "storagetier.restorer.media_not_required"
 }

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -55,6 +55,76 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
   val mockObject = mock[MxsObject]
   mockVault.getObject(any) returns mockObject
 
+  "PlutoCoreMessageProcessor.isBranding" should {
+
+    "return false if no GNM_TYPE" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+
+      val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty), None))
+
+      result must beFalse
+    }
+
+    "return false if GNM_TYPE is not exactly 'Branding': case 1 - lowercase" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "branding")), None))
+
+      result must beFalse
+    }
+
+    "return false if GNM_TYPE is not exactly 'Branding': case 2 - uppercase" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "BRANDING")), None))
+
+      result must beFalse
+    }
+
+    "return false if GNM_TYPE is not exactly 'Branding': case 3 - mixed" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "bRanDiNg")), None))
+
+      result must beFalse
+    }
+
+    "return false if GNM_TYPE is not exactly 'Branding': case 4 - rushes" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "rushes")), None))
+
+      result must beFalse
+    }
+
+    "return true if GNM_TYPE is exactly 'Branding'" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None))
+
+      result must beTrue
+    }
+
+    "filter out the branding items" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val entry = ObjectMatrixEntry("oid1", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None)
+      val entries = Seq(
+        ObjectMatrixEntry("oid1", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
+        ObjectMatrixEntry("oid2", Some(MxsMetadata.empty.withValue("GNM_TYPE", "rushes")), None),
+        ObjectMatrixEntry("oid3", Some(MxsMetadata.empty.withValue("GNM_TYPE", "branding")), None),
+        ObjectMatrixEntry("oid4§", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
+        ObjectMatrixEntry("oid5", Some(MxsMetadata.empty.withValue("GNM_TYPE", "project")), None),
+      )
+
+      val result = entries.filter(entry => !toTest.isBranding(entry))
+
+      result.size mustEqual 3
+      result.head.oid mustEqual "oid2"
+    }
+  }
+
   "PlutoCoreMessageProcessor" should {
 
     implicit val mockActorSystem = mock[ActorSystem]

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -113,7 +113,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
         VSOnlineOutputMessage("ONLINE", Seq(123), Some("a/path/5"), Some(1L), Some("VX-5"), Some("oid5"), "project"),
       )
 
-      val result = items.filter(item => !toTest.isBranding(item))
+      val result = items.filterNot(toTest.isBranding)
 
       result.size mustEqual 2
       result.head.itemId must beSome("VX-2")
@@ -178,13 +178,14 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
         ObjectMatrixEntry("oid1", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
         ObjectMatrixEntry("oid2", Some(MxsMetadata.empty.withValue("GNM_TYPE", "rushes")), None),
         ObjectMatrixEntry("oid3", Some(MxsMetadata.empty.withValue("GNM_TYPE", "branding")), None),
-        ObjectMatrixEntry("oid4§", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
+        ObjectMatrixEntry("oid4", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
         ObjectMatrixEntry("oid5", Some(MxsMetadata.empty.withValue("GNM_TYPE", "project")), None),
+        ObjectMatrixEntry("oid6", Some(MxsMetadata.empty), None),
       )
 
-      val result = entries.filter(entry => !toTest.isBranding(entry))
+      val result = entries.filterNot(toTest.isBranding)
 
-      result.size mustEqual 3
+      result.size mustEqual 4
       result.head.oid mustEqual "oid2"
     }
   }


### PR DESCRIPTION
## What does this change?

Filters out branding media items, so that no MediaNotRequired messages get sent for them.

## Why is the change needed?

We do **not** want to delete branding when a project using such is cleaned up.

## Important implementation details

We find the items to filter out by looking at
* in Vidispine, the field `gnm_asset_category` set to `Branding` (doing the check case-_insensitive_!)
* in Matrixstore, the field `GNM_TYPE` set to `Branding` (doing the check case-_sensitive_!)

(Also, the routing key fix has been cherry-picked from the `task/GP-790_delete_vs_item` branch.)
## Risks to consider when deploying

None really.
