### PR TITLE
GP-826 Filter out metadata and proxy items from outgoing remove nearline msgs

### DIFF
--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -61,8 +61,8 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig)(implicit mat: Mate
   // GP-823 Ensure that branding does not get deleted
   def isBranding(entry: ObjectMatrixEntry): Boolean = entry.stringAttribute("GNM_TYPE") match {
     case Some(gnmType) =>
-      gnmType match {
-        case "Branding" => true // Case sensitive
+      gnmType.toLowerCase match {
+        case "branding" => true // Case sensitive
         case _ => false
       }
     case _ => false
@@ -73,9 +73,9 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig)(implicit mat: Mate
   // (This will just remove the latest version of the metadata file, but is a known limitation and deemed acceptable for now.)
   def isMetadataOrProxy(entry: ObjectMatrixEntry): Boolean = entry.stringAttribute("GNM_TYPE") match {
     case Some(gnmType) =>
-      gnmType match {
-        case "metadata" => true // Case sensitive
-        case "proxy" => true // Case sensitive
+      gnmType.toLowerCase match {
+        case "metadata" => true
+        case "proxy" => true
         case _ => false
       }
     case _ => false

--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -52,6 +52,7 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig)(implicit mat: Mate
       Array("MXFS_PATH", "MXFS_FILENAME", "GNM_PROJECT_ID", "GNM_TYPE", "__mxs__length")
     )
     ).filterNot(isBranding)
+      .filterNot(isMetadataOrProxy)
       .map(entry => InternalOnlineOutputMessage.toOnlineOutputMessage(entry))
       .toMat(sinkFactory)(Keep.right)
       .run()
@@ -62,6 +63,19 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig)(implicit mat: Mate
     case Some(gnmType) =>
       gnmType match {
         case "Branding" => true // Case sensitive
+        case _ => false
+      }
+    case _ => false
+  }
+
+  // GP-826 Ensure that we don't emit Media not required-messages for proxy and metadata files, as media_remover uses
+  // ATT_PROXY_OID and ATT_META_OID on the main file to remove those.
+  // (This will just remove the latest version of the metadata file, but is a known limitation and deemed acceptable for now.)
+  def isMetadataOrProxy(entry: ObjectMatrixEntry): Boolean = entry.stringAttribute("GNM_TYPE") match {
+    case Some(gnmType) =>
+      gnmType match {
+        case "metadata" => true // Case sensitive
+        case "proxy" => true // Case sensitive
         case _ => false
       }
     case _ => false

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -131,28 +131,28 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       result must beFalse
     }
 
-    "return false if GNM_TYPE is not exactly 'Branding': case 1 - lowercase" in {
+    "return true if GNM_TYPE is not exactly 'Branding': case 1 - lowercase" in {
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig)
       val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "branding")), None))
 
-      result must beFalse
+      result must beTrue
     }
 
-    "return false if GNM_TYPE is not exactly 'Branding': case 2 - uppercase" in {
+    "return true if GNM_TYPE is not exactly 'Branding': case 2 - uppercase" in {
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig)
       val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "BRANDING")), None))
 
-      result must beFalse
+      result must beTrue
     }
 
-    "return false if GNM_TYPE is not exactly 'Branding': case 3 - mixed" in {
+    "return true if GNM_TYPE is not exactly 'Branding': case 3 - mixed" in {
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig)
       val result = toTest.isBranding(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "bRanDiNg")), None))
 
-      result must beFalse
+      result must beTrue
     }
 
     "return false if GNM_TYPE is not exactly 'Branding': case 4 - rushes" in {
@@ -185,7 +185,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
       val result = entries.filterNot(toTest.isBranding)
 
-      result.size mustEqual 4
+      result.size mustEqual 3
       result.head.oid mustEqual "oid2"
     }
   }
@@ -201,13 +201,13 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       result must beFalse
     }
 
-    "return false if GNM_TYPE is exactly 'Proxy'" in {
+    "return true if GNM_TYPE is exactly 'Proxy'" in {
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig)
 
       val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Proxy")), None))
 
-      result must beFalse
+      result must beTrue
     }
 
     "return true if GNM_TYPE is exactly 'proxy'" in {
@@ -243,7 +243,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
       val result = entries.filterNot(toTest.isMetadataOrProxy)
 
-      result.size mustEqual 7
+      result.size mustEqual 6
       result.head.oid mustEqual "oid1"
     }
   }

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -190,6 +190,64 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
     }
   }
 
+  "PlutoCoreMessageProcessor.isMetadataOrProxy(ObjectMatrixEntry)" should {
+
+    "return false if no GNM_TYPE" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+
+      val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty), None))
+
+      result must beFalse
+    }
+
+    "return false if GNM_TYPE is exactly 'Proxy'" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+
+      val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Proxy")), None))
+
+      result must beFalse
+    }
+
+    "return true if GNM_TYPE is exactly 'proxy'" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "proxy")), None))
+
+      result must beTrue
+    }
+
+    "return true if GNM_TYPE is exactly 'metadata'" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "metadata")), None))
+
+      result must beTrue
+    }
+
+    "filter out the 'metadata' and 'proxy' items" in {
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val entries = Seq(
+        ObjectMatrixEntry("oid1", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
+        ObjectMatrixEntry("oid2", Some(MxsMetadata.empty.withValue("GNM_TYPE", "rushes")), None),
+        ObjectMatrixEntry("oid3", Some(MxsMetadata.empty.withValue("GNM_TYPE", "branding")), None),
+        ObjectMatrixEntry("oid4", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
+        ObjectMatrixEntry("oid5", Some(MxsMetadata.empty.withValue("GNM_TYPE", "project")), None),
+        ObjectMatrixEntry("oid5", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Proxy")), None),
+        ObjectMatrixEntry("oid5", Some(MxsMetadata.empty.withValue("GNM_TYPE", "proxy")), None),
+        ObjectMatrixEntry("oid5", Some(MxsMetadata.empty.withValue("GNM_TYPE", "metadata")), None),
+        ObjectMatrixEntry("oid6", Some(MxsMetadata.empty), None),
+      )
+
+      val result = entries.filterNot(toTest.isMetadataOrProxy)
+
+      result.size mustEqual 7
+      result.head.oid mustEqual "oid1"
+    }
+  }
+
   "PlutoCoreMessageProcessor" should {
 
     implicit val mockActorSystem = mock[ActorSystem]


### PR DESCRIPTION
## What does this change?

We will not emit Media not required-messages for proxy and metadata files, as `media_remover` uses `ATT_PROXY_OID` and `ATT_META_OID` on the main file to remove those.

## Why is the change needed?

Finding proxy and metadata files on S3 is somewhat complex, as it requires knowledge of the parent's uploadPath to calculate the objectKey. (The latest version of) these files are already removed as part of the removal of the main object from nearline, so it was decided that we can skip sending messages and looking up the parent for now.

<!-- Prefer to copy-paste as not everyone may have access to Jira or Trello. References are ok in addition but please include enough context. -->

## Important implementation details

This will just remove the latest version of the metadata files for an OMS item, but is a known limitation and deemed acceptable for now.
<!-- e.g. some novel algorithm, or explaining iteraction between multiple components -->

## Risks to consider when deploying

<!-- does this touch live data? Are there database migrations that would complicate a roll-back? Is it just generally scary? -->
