### PR TITLE
Task/gp 790 delete vs item for (rebase)

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/models/media_remover/PendingDeletionRecordDAO.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/models/media_remover/PendingDeletionRecordDAO.scala
@@ -108,14 +108,18 @@ class PendingDeletionRecordDAO(override protected val db: Database)(implicit
       TableQuery[PendingDeletionRecordRow].filter(row => row.originalFilePath===filename && row.mediaTier===mediaTier).result
     ).map(_.headOption)
 
-  def findByOnlineId(vsid: String): Future[Option[PendingDeletionRecord]] =
+  def findByOnlineIdForONLINE(vsItemId: String): Future[Option[PendingDeletionRecord]] =
     db.run(
-      TableQuery[PendingDeletionRecordRow].filter(_.vidispineItemId===vsid).result
+      TableQuery[PendingDeletionRecordRow].filter(
+        row => row.vidispineItemId===vsItemId && row.mediaTier===MediaTiers.ONLINE
+      ).result
     ).map(_.headOption)
 
-  def findByNearlineId(oid: String): Future[Option[PendingDeletionRecord]] =
+  def findByNearlineIdForNEARLINE(oid: String): Future[Option[PendingDeletionRecord]] =
     db.run(
-      TableQuery[PendingDeletionRecordRow].filter(_.nearlineId===oid).result
+      TableQuery[PendingDeletionRecordRow].filter(
+        row => row.nearlineId===oid && row.mediaTier===MediaTiers.NEARLINE
+      ).result
     ).map(_.headOption)
 
 }

--- a/common/src/main/scala/com/gu/multimedia/storagetier/plutocore/AssetFolderLookup.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/plutocore/AssetFolderLookup.scala
@@ -125,7 +125,8 @@ class AssetFolderLookup (config:PlutoCoreConfig)(implicit mat:Materializer, acto
     }
   }
 
-  protected def putBackBase(path:Path):Either[String, Path] = {
+  def putBackBase(path:Path):Either[String, Path] = {
+    logger.info(s"config.assetFolderBasePath: ${config.assetFolderBasePath}")
     Try { config.assetFolderBasePath.resolve(path) } match {
       case Success(p)=>Right(p)
       case Failure(err)=>Left(err.getMessage)

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/FileMetadataValues.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/FileMetadataValues.scala
@@ -1,0 +1,4 @@
+package com.gu.multimedia.storagetier.vidispine
+
+case class FileMetadataFieldKeyValue(key:String, value:String)
+case class FileMetadata(field:Option[Seq[FileMetadataFieldKeyValue]])

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
@@ -2,21 +2,24 @@ package com.gu.multimedia.storagetier.vidispine
 
 import org.slf4j.LoggerFactory
 
-import java.time.ZonedDateTime
 
 case class VSShapeFile(
-                      id: String,
-                      path: String,
-                      uri: Option[Seq[String]],
-                      state: String,
-                      size: Long,
-                      hash: Option[String],
-                      timestamp: String,  //sure, this should really be a ZonedDateTime. But since we are not using the
-                      //field and it can cause parsing issues, keeping it as a String for the time being.
-                      refreshFlag: Int,
-                      storage: String,
+                        id: String,
+                        path: String,
+                        uri: Option[Seq[String]],
+                        state: String,
+                        size: Long,
+                        hash: Option[String],
+                        timestamp: String, //sure, this should really be a ZonedDateTime. But since we are not using the
+                        //field and it can cause parsing issues, keeping it as a String for the time being.
+                        refreshFlag: Int,
+                        storage: String,
+                        metadata: Option[FileMetadata],
                       ) extends FileDocumentUtils {
-  def sizeOption = if(size == -1) None else Some(size)
+  def sizeOption = if (size == -1) None else Some(size)
+
+  def md5Option =
+    metadata.flatMap(_.field.flatMap(_.filter(_.key == "hash-MD5").headOption.map(_.value)))
 }
 
 /**

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
@@ -1,5 +1,5 @@
 package com.gu.multimedia.storagetier.vidispine
-import com.gu.multimedia.storagetier.messages.VidispineField;
+import com.gu.multimedia.storagetier.messages.VidispineField
 import akka.actor.ActorSystem
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
@@ -83,6 +83,16 @@ class VidispineCommunicator(config:VidispineConfig) (implicit ec:ExecutionContex
         contentBodyToJson(consumeStream(entity.dataBytes))
     })
 
+  def deleteItem(vsItemId: String) = {
+    val response = callToVidispineRaw(
+      HttpRequest(
+        uri = s"${config.baseUri}/API/item/$vsItemId",
+        method = HttpMethods.DELETE
+      )
+    )
+    response.map(_.map(_.discardBytes()))
+  }
+  
   private def streamingVS(req:HttpRequest, readTimeout:FiniteDuration, thing:String) = callToVidispineRaw(req).map({
     case Some(entity)=>
       entity.dataBytes

--- a/common/src/test/resources/sample_shape_doc.json
+++ b/common/src/test/resources/sample_shape_doc.json
@@ -223,7 +223,18 @@
           "timestamp": "2021-10-05T13:18:08.374+0000",
           "refreshFlag": 1,
           "storage": "VX-6",
-          "metadata": {}
+          "metadata": {
+            "field": [
+              {
+                "key": "hash-MD5",
+                "value": "8a76d7e55d962e8fc9cc3f11d0d70256"
+              },
+              {
+                "key": "hash-SHA-256",
+                "value": "3e646f21536428ff858135e7b9fa00a5690bce4b8b72d7259c317f525df9990c"
+              }
+            ]
+          }
         }
       ],
       "id": "VX-451099",

--- a/common/src/test/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicatorSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicatorSpec.scala
@@ -69,9 +69,14 @@ class VidispineCommunicatorSpec extends Specification with AfterAll with Mockito
           Some("9a4192d38e12997716d9b389d73e6170614c7186"),
           "2021-10-05T13:18:08.374+0000",
           1,
-          "VX-6"
+          "VX-6",
+          Some(FileMetadata(Some(Seq(
+            FileMetadataFieldKeyValue("hash-MD5", "8a76d7e55d962e8fc9cc3f11d0d70256"),
+            FileMetadataFieldKeyValue("hash-SHA-256", "3e646f21536428ff858135e7b9fa00a5690bce4b8b72d7259c317f525df9990c"),
+          ))))
         )
       )
+      result.get.getLikelyFile.get.md5Option must beSome("8a76d7e55d962e8fc9cc3f11d0d70256")
     }
 
     "make a request to /API/item/shape for a video with no audio and unmarshal the return value" in {
@@ -109,9 +114,11 @@ class VidispineCommunicatorSpec extends Specification with AfterAll with Mockito
           Some("9d304c3e23bdbe1f153c746679fd2f1f6846f561"),
           "2018-09-19T14:06:44.435+0000",
           1,
-          "VX-6"
+          "VX-6",
+          Some(FileMetadata(None))
         )
       )
+      result.get.getLikelyFile.get.md5Option must beNone
     }
 
     "make a request to /API/item/shape for an audio only and unmarshal the return value" in {
@@ -149,7 +156,8 @@ class VidispineCommunicatorSpec extends Specification with AfterAll with Mockito
           Some("08a55101bb7f0afd9ca919817b5fbb59d86bba5e"),
           "2020-01-17T15:50:05.210+0000",
           1,
-          "VX-6"
+          "VX-6",
+          Some(FileMetadata(None))
         )
       )
     }

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -19,10 +19,10 @@ import io.circe.generic.auto._
 import io.circe.syntax._
 import matrixstore.MatrixStoreConfig
 import messages.MediaRemovedMessage
-import org.slf4j.{LoggerFactory, MDC}
+import org.slf4j.LoggerFactory
 
 import java.nio.file.Paths
-import java.util.{Map, UUID}
+import java.util.UUID
 import scala.concurrent.{ExecutionContext, Future}
 import scala.util.{Failure, Success, Try}
 
@@ -341,22 +341,6 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
         logger.warn(s"Could not verify checksum for file $filePath: ${err.getMessage}")
         Future(false)
     })
-  }
-
-  protected def getContextMap() = {
-    Option(MDC.getCopyOfContextMap)
-  }
-
-  protected def setContextMap(contextMap: Map[String, String]) = {
-    MDC.setContextMap(contextMap)
-  }
-
-  protected def getOMFileMd5(mxsFile: MxsObject) = {
-    MatrixStoreHelper.getOMFileMd5(mxsFile)
-  }
-
-  protected def getSizeFromMxs(mxsFile: MxsObject) = {
-    MetadataHelper.getFileSize(mxsFile)
   }
 
 

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -430,7 +430,7 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
               logger.error(s"Unable to get checksum from appliance ${vault.getId}, file with $oid should be considered unsafe", err)
               Future(None)
             case Success(remoteChecksum) =>
-              logger.info(s"Appliance reported checksum of $remoteChecksum for $oid on $vault")
+              logger.info(s"Appliance reported checksum of $remoteChecksum for $oid on ${vault.getId}")
               Future(Some(remoteChecksum))
           })
       } yield maybeMd5

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -485,11 +485,11 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
       case ("NEARLINE", _, _) =>
         Future.failed(new RuntimeException("NEARLINE but no nearlineId"))
 
-      case ("ONLINE", Some(onlineId), _) =>
-        logger.warn(s"Not implemented yet - $onlineId ignored")
-        Future.failed(SilentDropMessage(Some(s"Not implemented yet - $onlineId ignored")))
+      case ("ONLINE", Some(vsItemId), _) =>
+        logger.warn(s"Not implemented yet - $vsItemId ignored")
+        Future.failed(SilentDropMessage(Some(s"Not implemented yet - $vsItemId ignored")))
       case ("ONLINE", _, _) =>
-        Future.failed(new RuntimeException("ONLINE but no onlineId"))
+        Future.failed(new RuntimeException("ONLINE but no itemId"))
 
       case (_, _, _) =>
         Future.failed(new RuntimeException("This should not happen!"))

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -619,7 +619,7 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
       case Some(project) =>
         project.status match {
           case status if status == EntryStatus.Held =>
-            (Action.CheckNearline, Some(project))
+            (Action.CheckExistsOnNearline, Some(project))
           case _ =>
             project.deletable match {
               case Some(true) =>
@@ -894,7 +894,7 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
       case (Action.CheckInternalArchive, Some(_)) =>
         handleCheckVaultForOnline(internalArchiveVault, onlineOutputMessage, NOT_IMPL_outputInternalArchiveCopyRequired)
 
-      case (Action.CheckNearline, Some(_)) =>
+      case (Action.CheckExistsOnNearline, Some(_)) =>
         handleCheckVaultForOnline(nearlineVault, onlineOutputMessage, NOT_IMPL_outputNearlineCopyRequired)
 
       case (Action.ClearAndDelete, Some(_)) =>
@@ -922,6 +922,6 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
 
 object MediaNotRequiredMessageProcessor {
   object Action extends Enumeration {
-    val CheckDeepArchiveForNearline, CheckInternalArchive, ClearAndDelete, DropMsg, JustNo, CheckNearline, CheckDeepArchiveForOnline  = Value
+    val CheckDeepArchiveForNearline, CheckInternalArchive, ClearAndDelete, DropMsg, JustNo, CheckExistsOnNearline, CheckDeepArchiveForOnline  = Value
   }
 }

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -866,22 +866,21 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
       actionToPerform <- Future(getActionToPerformOnline(onlineOutputMessage, projectRecordMaybe))
       fileRemoveResult <- performActionOnline(vault, internalArchiveVault, onlineOutputMessage, actionToPerform)
     } yield fileRemoveResult
-
-    Future(Left("testing online"))
   }
+
 
   def performActionOnline(nearlineVault: Vault, internalArchiveVault: Vault, onlineOutputMessage: OnlineOutputMessage, actionToPerform: (MediaNotRequiredMessageProcessor.Action.Value, Option[ProjectRecord])): Future[Either[String, MessageProcessorReturnValue]] = {
     actionToPerform match {
-      case (Action.CheckDeepArchiveForOnline, Some(project)) =>
+      case (Action.CheckDeepArchiveForOnline, Some(_)) =>
         handleCheckDeepArchiveForOnline(onlineOutputMessage)
 
-      case (Action.CheckInternalArchive, Some(project)) =>
+      case (Action.CheckInternalArchive, Some(_)) =>
         handleCheckVaultForOnline(internalArchiveVault, onlineOutputMessage, NOT_IMPL_outputInternalArchiveCopyRequired)
 
-      case (Action.CheckNearline, Some(project)) =>
+      case (Action.CheckNearline, Some(_)) =>
         handleCheckVaultForOnline(nearlineVault, onlineOutputMessage, NOT_IMPL_outputNearlineCopyRequired)
 
-      case (Action.ClearAndDelete, Some(project)) =>
+      case (Action.ClearAndDelete, Some(_)) =>
         handleDeleteOnlineAndClear(onlineOutputMessage)
 
       case (Action.DropMsg, None) =>

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -587,11 +587,35 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
     }
 
 
-  def NOT_IMPL_outputDeepArchiveCopyRequired(onlineOutputMessage: OnlineOutputMessage): Future[Either[String, MessageProcessorReturnValue]] = ???
-  def NOT_IMPL_outputDeepArchiveCopyRequired(pendingDeletionRecord: PendingDeletionRecord): Future[Either[String, MessageProcessorReturnValue]] = ???
-  def NOT_IMPL_outputInternalArchiveCopyRequired(onlineOutputMessage: OnlineOutputMessage): Future[Either[String, MessageProcessorReturnValue]] = ???
-  def NOT_IMPL_outputNearlineCopyRequired(onlineOutputMessage: OnlineOutputMessage): Future[Either[String, MessageProcessorReturnValue]] = ???
-  def NOT_IMPL_outputInternalArchiveCopyRequired(pendingDeletionRecord: PendingDeletionRecord): Future[Either[String, MessageProcessorReturnValue]] = ???
+  def NOT_IMPL_outputDeepArchiveCopyRequired(onlineOutputMessage: OnlineOutputMessage): Future[Either[String, MessageProcessorReturnValue]] = {
+    val message = s"outputDeepArchiveCopyRequired not implemented yet, erring on the safe side, not removing ${onlineOutputMessage.originalFilePath}"
+    logger.warn(message)
+    throw SilentDropMessage(Some(message))
+  }
+
+  def NOT_IMPL_outputDeepArchiveCopyRequired(pendingDeletionRecord: PendingDeletionRecord): Future[Either[String, MessageProcessorReturnValue]] = {
+    val message = s"outputDeepArchiveCopyRequired not implemented yet, erring on the safe side, not removing ${pendingDeletionRecord.originalFilePath}"
+    logger.warn(message)
+    throw SilentDropMessage(Some(message))
+  }
+
+  def NOT_IMPL_outputInternalArchiveCopyRequired(onlineOutputMessage: OnlineOutputMessage): Future[Either[String, MessageProcessorReturnValue]] = {
+    val message = s"outputInternalArchiveCopyRequired not implemented yet, erring on the safe side, not removing ${onlineOutputMessage.originalFilePath}"
+    logger.warn(message)
+    throw SilentDropMessage(Some(message))
+  }
+
+  def NOT_IMPL_outputInternalArchiveCopyRequired(pendingDeletionRecord: PendingDeletionRecord): Future[Either[String, MessageProcessorReturnValue]] = {
+    val message = s"outputInternalArchiveCopyRequired not implemented yet, erring on the safe side, not removing ${pendingDeletionRecord.originalFilePath}"
+    logger.warn(message)
+    throw SilentDropMessage(Some(message))
+  }
+
+  def NOT_IMPL_outputNearlineCopyRequired(onlineOutputMessage: OnlineOutputMessage): Future[Either[String, MessageProcessorReturnValue]] = {
+    val message = s"outputNearlineCopyRequired not implemented yet, erring on the safe side, not removing ${onlineOutputMessage.originalFilePath}"
+    logger.warn(message)
+    throw SilentDropMessage(Some(message))
+  }
 
 
   def storeDeletionPending(msg: OnlineOutputMessage): Future[Either[String, Int]] =

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -475,8 +475,9 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
               logger.debug(s"Deleting pendingDeletionRecord ${existingRecord.id.getOrElse(-1)} for ${msg.mediaTier}, oid $nearlineId")
               pendingDeletionRecordDAO.deleteRecord(existingRecord).map(i => Right(i))
             case None=>
-              Future(Left("Should not happen"))
+              Future(Right(0))
           })
+
       case ("NEARLINE", _, _) =>
         Future.failed(new RuntimeException("NEARLINE but no nearlineId"))
 
@@ -488,7 +489,7 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
               logger.debug(s"Deleting pendingDeletionRecord ${existingRecord.id.getOrElse(-1)} for ${msg.mediaTier}, vsItemId $vsItemId")
               pendingDeletionRecordDAO.deleteRecord(existingRecord).map(i => Right(i))
             case None=>
-              Future(Left("Should not happen"))
+              Future(Right(0))
           })
 
       case ("ONLINE", _, _) =>

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -480,6 +480,10 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
         pendingDeletionRecordDAO
           .findByNearlineIdForNEARLINE(nearlineId)
           .flatMap({
+            // The number returned in the Right is the number of affected rows.
+            // We always call this method when we delete an item, instead of first checking
+            // if there exists a pending deletetion => if none is found, that's not an
+            // error, but obviously no rows are updated, hence Right(0) in that case.
             case Some(existingRecord)=>
               logger.debug(s"Deleting pendingDeletionRecord ${existingRecord.id.getOrElse(-1)} for ${msg.mediaTier}, oid $nearlineId")
               pendingDeletionRecordDAO.deleteRecord(existingRecord).map(i => Right(i))

--- a/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
+++ b/media_remover/src/main/scala/MediaNotRequiredMessageProcessor.scala
@@ -453,15 +453,16 @@ class MediaNotRequiredMessageProcessor(asLookup: AssetFolderLookup)(
   }
 
 
-  private def putItBack(filePath: String): String = filePath match {
+  def putItBack(filePath: String): String = filePath match {
     case f if f.startsWith("/") =>
+      logger.debug(s"$filePath is absolute, returning without putting base back")
       filePath
     case _ => asLookup.putBackBase(Paths.get(filePath)) match {
       case Left(err) =>
         logger.warn(s"Could not but back base path for $filePath: $err. Will use as was.")
         filePath
       case Right(value) =>
-        logger.debug(s"$filePath was restored to ${value.toString}")
+        logger.debug(s"$filePath had the base put back to form ${value.toString}")
         value.toString
     }
   }

--- a/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
+++ b/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
@@ -1,6 +1,6 @@
 import MediaNotRequiredMessageProcessor.Action
 import akka.actor.ActorSystem
-import akka.http.javadsl.model.HttpMessage.DiscardedEntity
+import akka.http.scaladsl.model.HttpMessage.DiscardedEntity
 import akka.http.scaladsl.model.HttpMessage
 import akka.stream.Materializer
 import com.gu.multimedia.mxscopy.{ChecksumChecker, MXSConnectionBuilderImpl}

--- a/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
+++ b/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
@@ -1,3 +1,4 @@
+import MediaNotRequiredMessageProcessor.Action
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.gu.multimedia.mxscopy.{ChecksumChecker, MXSConnectionBuilderImpl}

--- a/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
+++ b/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
@@ -313,7 +313,7 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
     "store new record for NEARLINE if no record found" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
-      pendingDeletionRecordDAO.findBySourceFilenameAndMediaTier(any, any) returns Future(None)
+      pendingDeletionRecordDAO.findByNearlineIdForNEARLINE(any) returns Future(None)
       pendingDeletionRecordDAO.writeRecord(any) returns Future(234)
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -353,7 +353,7 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
       val existingRecord = PendingDeletionRecord(Some(234), "some/file/path", Some("nearline-test-id"), Some("vsid"), MediaTiers.NEARLINE, 1)
       val expectedUpdatedRecordToSave = PendingDeletionRecord(Some(234), "some/file/path", Some("nearline-test-id"), Some("vsid"), MediaTiers.NEARLINE, 2)
-      pendingDeletionRecordDAO.findBySourceFilenameAndMediaTier(any, any) returns Future(Some(existingRecord))
+      pendingDeletionRecordDAO.findByNearlineIdForNEARLINE(any) returns Future(Some(existingRecord))
       pendingDeletionRecordDAO.writeRecord(expectedUpdatedRecordToSave) returns Future(234)
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]

--- a/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
+++ b/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
@@ -7,7 +7,7 @@ import com.gu.multimedia.storagetier.framework.MessageProcessorConverters._
 import com.gu.multimedia.storagetier.messages.{AssetSweeperNewFile, OnlineOutputMessage}
 import com.gu.multimedia.storagetier.models.common.MediaTiers
 import com.gu.multimedia.storagetier.models.media_remover.{PendingDeletionRecord, PendingDeletionRecordDAO}
-import com.gu.multimedia.storagetier.models.nearline_archive.{FailureRecordDAO, NearlineRecord, NearlineRecordDAO}
+import com.gu.multimedia.storagetier.models.nearline_archive.NearlineRecord
 import com.gu.multimedia.storagetier.plutocore.EntryStatus
 import messages.MediaRemovedMessage
 
@@ -36,11 +36,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
   "MediaNotRequiredMessageProcessor.getChecksumForNearlineItem" should {
     "fail if no nearline id" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -50,9 +45,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
 
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
@@ -94,11 +86,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
   "MediaNotRequiredMessageProcessor.deleteFromNearline" should {
     "fail if no nearline id" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -107,9 +94,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
 
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
@@ -289,8 +273,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
     "fail if no filePath" in {
 
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
       pendingDeletionRecordDAO.writeRecord(any) returns Future(234)
 
@@ -329,8 +311,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "store new record for NEARLINE if no record found" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
       pendingDeletionRecordDAO.findBySourceFilenameAndMediaTier(any, any) returns Future(None)
       pendingDeletionRecordDAO.writeRecord(any) returns Future(234)
@@ -369,8 +349,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "store updated record for NEARLINE if record already present" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
       val existingRecord = PendingDeletionRecord(Some(234), "some/file/path", Some("nearline-test-id"), Some("vsid"), MediaTiers.NEARLINE, 1)
       val expectedUpdatedRecordToSave = PendingDeletionRecord(Some(234), "some/file/path", Some("nearline-test-id"), Some("vsid"), MediaTiers.NEARLINE, 2)
@@ -413,11 +391,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "22 route nearline deletable Completed project with deliverable media should drop silently" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -427,9 +400,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
 
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
@@ -475,11 +445,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "23 route nearline deletable Killed project with deliverable media should drop silently " in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -488,8 +453,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
 
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
@@ -535,11 +498,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "24 route nearline Deletable & Killed project with media not of type Deliverables should remove media" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -548,9 +506,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableCompletedAndDeliverable = mock[ProjectRecord]
@@ -602,11 +557,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "26 route nearline Deletable & Completed project with media not of type Deliverables should remove media" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -615,9 +565,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableAndKilled = mock[ProjectRecord]
@@ -669,11 +616,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "27 route nearline Deletable & New project should silent drop" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -682,9 +624,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableAndKilled = mock[ProjectRecord]
@@ -727,11 +666,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "28 route nearline p:deep_archive and NOT p:sensitive & p:Killed & m:Exists on Deep Archive should remove media" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -740,9 +674,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableCompletedAndDeliverable = mock[ProjectRecord]
@@ -797,11 +728,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "29 route nearline p:deep_archive and NOT p:sensitive & p:Killed & m:Does not exist on Deep Archive should Store pending & Request copy" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -810,9 +736,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableCompletedAndDeliverable = mock[ProjectRecord]
@@ -867,11 +790,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "30 route nearline p:deep_archive and NOT p:sensitive & not p:Killed and not p:Completed should silent drop" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -880,9 +798,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableCompletedAndDeliverable = mock[ProjectRecord]
@@ -926,11 +841,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
 
     "31 route nearline p:deep_archive and p:sensitive & p:Killed & m:Exists on Internal Archive should remove media" in {
       val mockMsgFramework = mock[MessageProcessingFramework]
-      implicit val nearlineRecordDAO:NearlineRecordDAO = mock[NearlineRecordDAO]
-      nearlineRecordDAO.writeRecord(any) returns Future(123)
-      nearlineRecordDAO.findBySourceFilename(any) returns Future(None)
-      implicit val failureRecordDAO:FailureRecordDAO = mock[FailureRecordDAO]
-      failureRecordDAO.writeRecord(any) returns Future(234)
       implicit val pendingDeletionRecordDAO :PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
 
       implicit val vidispineCommunicator = mock[VidispineCommunicator]
@@ -939,9 +849,6 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
       implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
       implicit val mockChecksumChecker = mock[ChecksumChecker]
-      val mockCheckForPreExistingFiles = mock[(Vault, AssetSweeperNewFile)=>Future[Option[NearlineRecord]]]
-      mockCheckForPreExistingFiles.apply(any,any) returns Future(None)
-
       val mockAssetFolderLookup = mock[AssetFolderLookup]
 
       val fakeProjectDeletableCompletedAndDeliverable = mock[ProjectRecord]

--- a/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
+++ b/media_remover/src/test/scala/MediaNotRequiredMessageProcessorSpec.scala
@@ -2734,8 +2734,37 @@ class MediaNotRequiredMessageProcessorSpec extends Specification with Mockito {
       result.get must beRight
       result.get.right.get.content.\\("content").head.as[MediaRemovedMessage].right.get.vidispineItemId must beSome("VX-151931")
     }
-
-
   }
+
+
+  "MediaNotRequiredMessageProcessor.dealWithAttFiles" should {
+    "handle failed fromOID" in {
+
+      implicit val nearlineRecordDAO: NearlineRecordDAO = mock[NearlineRecordDAO]
+      implicit val failureRecordDAO: FailureRecordDAO = mock[FailureRecordDAO]
+      implicit val pendingDeletionRecordDAO: PendingDeletionRecordDAO = mock[PendingDeletionRecordDAO]
+      implicit val vidispineCommunicator = mock[VidispineCommunicator]
+      implicit val mat: Materializer = mock[Materializer]
+      implicit val sys: ActorSystem = mock[ActorSystem]
+      implicit val mockBuilder = mock[MXSConnectionBuilderImpl]
+      implicit val mockS3ObjectChecker = mock[S3ObjectChecker]
+      implicit val mockChecksumChecker = mock[ChecksumChecker]
+      val mockAssetFolderLookup = mock[AssetFolderLookup]
+
+      val vault = mock[Vault]
+      vault.getId returns "mockVault"
+
+      val filePath = "/path/to/some/file.ext"
+
+      val toTest = new MediaNotRequiredMessageProcessor(mockAssetFolderLookup) {
+        override protected def callObjectMatrixEntryFromOID(vault: Vault, fileName: String) = Future.fromTry(Failure(new RuntimeException("no oid for you")))
+      }
+
+      val result = Await.result(toTest.dealWithAttFiles(vault, "556593b10503", filePath), 2.seconds)
+
+      result must beLeft("Something went wrong while trying to get metadata to delete ATT files for 556593b10503: java.lang.RuntimeException: no oid for you")
+    }
+  }
+
 
 }

--- a/online_archive/src/main/scala/FileUploader.scala
+++ b/online_archive/src/main/scala/FileUploader.scala
@@ -25,12 +25,11 @@ class FileUploader(transferManager: S3TransferManager, client: S3Client, var buc
 
   /**
    * Attempt to copy the given file to S3 under a distinct name.
-   * If a file with the same name AND the same file size exists, then returns a Success with the found file name
+   * If a file with the same name AND the same file size exists, then returns a Success with the found file name.
+   * If a file with the same name but a DIFFERENT file size exists, the file is then uploaded and a Success returned
+   * with a tuple containing the file name and file size.
    * If no file with the name exists, will upload it and return a Success with the file name as uploaded.
-   * If a file with the same name but a DIFFERENT file size exists, will suffix the name "-1", "-2" etc. until a 'free'
-   * filename is found. The file is then uploaded and a Success returned with a Tuple containing the the uploaded file name and file
-   * size.
-   * If there is an error, then Failure is returned
+   * If there is an error, then Failure is returned.
    * @param file a java.io.File instance representing the file to upload
    * @param maybeUploadPath Optional destination path to upload it to. If not set, then the absolute path of `file` is used.
    * @return a Try, containing a Tuple where the first value is a String containing the uploaded file name and the second value is a

--- a/online_archive/src/test/scala/VidispineFunctionsSpec.scala
+++ b/online_archive/src/test/scala/VidispineFunctionsSpec.scala
@@ -89,7 +89,8 @@ class VidispineFunctionsSpec extends Specification with Mockito {
           Some("deadbeef"),
           "2021-01-02T03:04:05.678Z",
           1,
-          "VX-2"
+          "VX-2",
+          None
         )
         VidispineFunctions.uploadKeyForProxy(testArchivedRecord, testProxy) mustEqual "path/to/uploaded/file_prox.mp4"
       }
@@ -112,7 +113,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
           Some("deadbeef"),
           "2021-01-02T03:04:05.678Z",
           1,
-          "VX-2"
+          "VX-2", None
         )
         VidispineFunctions.uploadKeyForProxy(testArchivedRecord, testProxy) mustEqual "path/to/uploaded/file_prox"
       }
@@ -134,7 +135,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
         Some("deadbeef"),
         "",
         1,
-        "VX-3"
+        "VX-3", None
       )
       val shapeDoc = ShapeDocument(
         "VX-456",
@@ -277,7 +278,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
         Some("deadbeef"),
         "",
         1,
-        "VX-3"
+        "VX-3", None
       )
       val shapeDoc = ShapeDocument(
         "VX-456",
@@ -335,7 +336,7 @@ class VidispineFunctionsSpec extends Specification with Mockito {
         Some("deadbeef"),
         "",
         1,
-        "VX-3"
+        "VX-3", None
       )
       val shapeDoc = ShapeDocument(
         "VX-456",

--- a/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_archive/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -87,7 +87,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
 
     "call out to uploadIfRequiredAndNotExists" in {
 
-      val mockVSFile = VSShapeFile("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2")
+      val mockVSFile = VSShapeFile("VX-1234","relative/path.mp4",Some(Seq("file:///absolute/path/relative/path.mp4")), "CLOSED", 123456L, Some("deadbeef"), "2020-01-02T03:04:05Z", 1, "VX-2", None)
       implicit val mockVSCommunicator = mock[VidispineCommunicator]
 
       mockVSCommunicator.findItemFile(any, any) returns Future(Some(mockVSFile))

--- a/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
+++ b/online_nearline/src/test/scala/VidispineMessageProcessorSpec.scala
@@ -362,7 +362,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
 
       val mockShape = mock[ShapeDocument]
       mockShape.tag returns Seq("original")
-      mockShape.getLikelyFile returns Some(VSShapeFile("VX-8888","/path/to/some/file",None,"CLOSED",1234L,None,"2012-01-02T03:04:05Z",1, "VX-4"))
+      mockShape.getLikelyFile returns Some(VSShapeFile("VX-8888","/path/to/some/file",None,"CLOSED",1234L,None,"2012-01-02T03:04:05Z",1, "VX-4", None))
       mockVSCommunicator.listItemShapes(any) returns Future(Some(Seq(mockShape)))
 
       val mockCheckForPreExisting = mock[(Vault, Path, QueryableItem, Boolean)=>Future[Option[NearlineRecord]]]
@@ -1294,7 +1294,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("deadbeef"),
         "2021-01-02T03:04:05.678Z",
         1,
-        "VX-2"
+        "VX-2", None
       )
 
       val mediaIngested = VidispineMediaIngested(List(
@@ -1361,7 +1361,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("deadbeef"),
         "2021-01-02T03:04:05.678Z",
         1,
-        "VX-2"
+        "VX-2", None
       )
 
       val mediaIngested = VidispineMediaIngested(List(
@@ -1481,7 +1481,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("deadbeef"),
         "2021-01-02T03:04:05.678Z",
         1,
-        "VX-2"
+        "VX-2", None
       )
       val mockShapeDoc = mock[ShapeDocument]
       mockShapeDoc.getLikelyFile returns Some(mockShapeFile)
@@ -1532,7 +1532,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
         Some("deadbeef"),
         "2021-01-02T03:04:05.678Z",
         1,
-        "VX-2"
+        "VX-2", None
       )
       val mockShapeDoc = mock[ShapeDocument]
       mockShapeDoc.getLikelyFile returns Some(mockShapeFile)
@@ -1566,7 +1566,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
           None,
           Some(SimplifiedComponent(
             "VX-1212",
-            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
+            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage, None))
           )),
           None,
           None,
@@ -1689,7 +1689,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
           None,
           Some(SimplifiedComponent(
             "VX-1212",
-            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
+            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage, None))
           )),
           None,
           None,
@@ -1756,7 +1756,7 @@ class VidispineMessageProcessorSpec extends Specification with Mockito {
           None,
           Some(SimplifiedComponent(
             "VX-1212",
-            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage))
+            Seq(VSShapeFile(mockedFile.id, mockedFile.path, mockedFile.uri, mockedFile.state, mockedFile.size, mockedFile.hash, mockedFile.timestamp, mockedFile.refreshFlag, mockedFile.storage, None))
           )),
           None,
           None,


### PR DESCRIPTION
## What does this change?

<!-- list out the headlines of what's going on -->
Implements the second pillar of `MediaNotRequiredProcessor`, namely handling removal of media from the online (Vidispine) storage.

Obviously, there are several checks to see if it is appropriate to actually delete a media item, including checks of project state, media existing on nearline, internal archive or deep archive if needed, etc.

## Why is the change needed?

Remove media from online, to lessen space used.


<!-- Prefer to copy-paste as not everyone may have access to Jira or Trello. References are ok in addition but please include enough context. -->

## Important implementation details
- **Getting the MD5 of online (vidispine) media by parsing also metadata in `VSShapeFile` (NB **_not_** added to `FileDocument`)**
- Reworked looking up `PendingDeletionRecord`s, as filepath is not unique (because of versioning)
- Extracted methods from `performActionNearline` 
  - easier to see logic
  - some also usable by `performActionOnline`

<!-- e.g. some novel algorithm, or explaining interaction between multiple components -->
**Still missing**
* Self-healing loop when media doesn't exists where it needs to exist for backup purposes
* ~Not yet getting the MD5 checksum of online files to use in check for matching files - currently relying on filepath + filesize solely.~

**Known limitations**
* Does not properly look up metadata and proxy files when they need to be checked on S3, which means most of them will not be deleted when a deep archive check is required
  * However, the latest metadata and proxy file should still be deleted for a main asset, if the asset is OK to be deleted. 

## Risks to consider when deploying

<!-- does this touch live data? Are there database migrations that would complicate a roll-back? Is it just generally scary? -->
