### PR TITLE
Task/gp 824 handle crosslinked media

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
@@ -58,8 +58,7 @@ object VSOnlineOutputMessage {
     val likelyFile = itemSimplified.item.shape.head.getLikelyFile
     val filePath = likelyFile.flatMap(_.getAbsolutePath)
     val fileSize = likelyFile.flatMap(_.sizeOption)
-    val containingProjects = projectId +: itemSimplified.valuesForField("gnm_containing_projects", Some("Asset")).map(_.value).map(_.toInt)
-    println(s">>> $containingProjects")
+    val projectIdAndContainingProjectIds = projectId +: itemSimplified.valuesForField("gnm_containing_projects", Some("Asset")).map(_.value).map(_.toInt)
     val nearlineId = itemSimplified
       .valuesForField("gnm_nearline_id", Some("Asset"))
       .headOption
@@ -73,8 +72,7 @@ object VSOnlineOutputMessage {
         Some(
           VSOnlineOutputMessage(
             mediaTier,
-//            Seq(projectId),
-            containingProjects,
+            projectIdAndContainingProjectIds,
             filePath,
             fileSize,
             Some(itemId),

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
@@ -58,6 +58,8 @@ object VSOnlineOutputMessage {
     val likelyFile = itemSimplified.item.shape.head.getLikelyFile
     val filePath = likelyFile.flatMap(_.getAbsolutePath)
     val fileSize = likelyFile.flatMap(_.sizeOption)
+    val containingProjects = projectId +: itemSimplified.valuesForField("gnm_containing_projects", Some("Asset")).map(_.value).map(_.toInt)
+    println(s">>> $containingProjects")
     val nearlineId = itemSimplified
       .valuesForField("gnm_nearline_id", Some("Asset"))
       .headOption
@@ -71,7 +73,8 @@ object VSOnlineOutputMessage {
         Some(
           VSOnlineOutputMessage(
             mediaTier,
-            Seq(projectId),
+//            Seq(projectId),
+            containingProjects,
             filePath,
             fileSize,
             Some(itemId),

--- a/common/src/test/scala/com/gu/multimedia/storagetier/plutocore/AssetFolderLookupSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/plutocore/AssetFolderLookupSpec.scala
@@ -10,6 +10,18 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 class AssetFolderLookupSpec extends Specification with Mockito{
   "AssetFolderLookup.relativizeFilePath" should {
+
+    "correctly wrap a call to relativizeFilePath for the test env" in {
+      implicit val mat = mock[Materializer]
+      implicit val system = mock[ActorSystem]
+      val fakeConfig = PlutoCoreConfig("test","test",Paths.get("/srv/Multimedia2/NextGenDev/Media Production/Assets/"))
+      val toTest = new AssetFolderLookup(fakeConfig) {
+        def callRelativize(path:Path) = relativizeFilePath(path)
+      }
+
+      toTest.callRelativize(Paths.get("/srv/Multimedia2/NextGenDev/Media Production/Assets/Fred_In_Bed/This_Is_A_Test/david_allison_Deletion_Test_Completed_6/Title 02.mp4")) must beRight(Paths.get("Fred_In_Bed/This_Is_A_Test/david_allison_Deletion_Test_Completed_6/Title 02.mp4"))
+    }
+
     "correctly wrap a call to relativizeFilePath" in {
       implicit val mat = mock[Materializer]
       implicit val system = mock[ActorSystem]

--- a/common/src/test/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicatorSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicatorSpec.scala
@@ -333,8 +333,6 @@ class VidispineCommunicatorSpec extends Specification with AfterAll with Mockito
       }
 
       val result = Await.result(toTest.getFilesOfProject(23, 100), 1.second)
-      result.foreach(f => println(s"result fbp: ${f.projectIds}"))
-//      println(s"result fbp: $result")
       result.size mustEqual 44
     }
   }

--- a/common/src/test/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicatorSpec.scala
+++ b/common/src/test/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicatorSpec.scala
@@ -333,6 +333,8 @@ class VidispineCommunicatorSpec extends Specification with AfterAll with Mockito
       }
 
       val result = Await.result(toTest.getFilesOfProject(23, 100), 1.second)
+      result.foreach(f => println(s"result fbp: ${f.projectIds}"))
+//      println(s"result fbp: $result")
       result.size mustEqual 44
     }
   }

--- a/media_remover/src/main/scala/Main.scala
+++ b/media_remover/src/main/scala/Main.scala
@@ -37,7 +37,7 @@ object Main {
     case Right(config)=>config
   }
 
-  val assetFolderLookup = new AssetFolderLookup(plutoConfig)
+//  val assetFolderLookup = new AssetFolderLookup(plutoConfig)
 
   //maximum time (in seconds) to keep an idle connection open
   private val connectionIdleTime = sys.env.getOrElse("CONNECTION_MAX_IDLE", "750").toInt

--- a/media_remover/src/main/scala/Main.scala
+++ b/media_remover/src/main/scala/Main.scala
@@ -37,8 +37,6 @@ object Main {
     case Right(config)=>config
   }
 
-//  val assetFolderLookup = new AssetFolderLookup(plutoConfig)
-
   //maximum time (in seconds) to keep an idle connection open
   private val connectionIdleTime = sys.env.getOrElse("CONNECTION_MAX_IDLE", "750").toInt
 

--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -182,13 +182,6 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig, asLookup: AssetFol
       case _ => Future.failed(SilentDropMessage(Some(s"Incoming project update message has a status we don't care about (${updateMessage.status}), dropping it.")))
     }
 
-  private def logPreAndPostCrosslinkFiltering(onlineResults: Seq[OnlineOutputMessage], nearlineResults: Seq[OnlineOutputMessage], filteredNearline: Seq[OnlineOutputMessage], filteredOnline: Seq[OnlineOutputMessage]) = {
-    if (nearlineResults.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"nearlineResults: ${nearlineResults.map(_.nearlineId.getOrElse("<missing>"))}") else logger.debug(s"${nearlineResults.size} nearline results")
-    if (filteredNearline.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"filteredNearlineResults: ${filteredNearline.map(_.nearlineId.getOrElse("<missing>"))}") else logger.debug(s"${nearlineResults.size} filtered nearline results")
-    if (onlineResults.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"onlineResults: ${onlineResults.map(_.vidispineItemId.getOrElse("<missing>"))}") else logger.debug(s"${onlineResults.size} online results")
-    if (filteredOnline.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"filteredOnlineResults: ${filteredOnline.map(_.vidispineItemId.getOrElse("<missing>"))}") else logger.debug(s"${filteredOnline.size} filtered online results")
-  }
-
   private def processResults(nearlineResults: Seq[OnlineOutputMessage], onlineResults: Seq[OnlineOutputMessage], routingKey: String, framework: MessageProcessingFramework, projectId: Int, projectStatus: String): Either[String, MessageProcessorReturnValue] =
     if (nearlineResults.length < 10000 && onlineResults.length < 10000) {
       logger.info(s"About to send bulk messages for ${nearlineResults.length} nearline results")
@@ -238,6 +231,12 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig, asLookup: AssetFol
         logger.warn(s"Dropping message $routingKey from own exchange as I don't know how to handle it. This should be fixed in the code.")
         Future.failed(new RuntimeException("Not meant to receive this"))
     }
+  }
+  private def logPreAndPostCrosslinkFiltering(onlineResults: Seq[OnlineOutputMessage], nearlineResults: Seq[OnlineOutputMessage], filteredNearline: Seq[OnlineOutputMessage], filteredOnline: Seq[OnlineOutputMessage]) = {
+    if (nearlineResults.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"nearlineResults: ${nearlineResults.map(_.nearlineId.getOrElse("<missing>"))}") else logger.debug(s"${nearlineResults.size} nearline results")
+    if (filteredNearline.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"filteredNearlineResults: ${filteredNearline.map(_.nearlineId.getOrElse("<missing>"))}") else logger.debug(s"${nearlineResults.size} filtered nearline results")
+    if (onlineResults.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"onlineResults: ${onlineResults.map(_.vidispineItemId.getOrElse("<missing>"))}") else logger.debug(s"${onlineResults.size} online results")
+    if (filteredOnline.size < MAX_ITEMS_TO_LOG_INDIVIDUALLY) logger.debug(s"filteredOnlineResults: ${filteredOnline.map(_.vidispineItemId.getOrElse("<missing>"))}") else logger.debug(s"${filteredOnline.size} filtered online results")
   }
 }
 

--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -39,8 +39,7 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig, asLookup: AssetFol
 
   def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = {
     vidispineCommunicator.getFilesOfProject(projectId)
-      .map(_.filterNot(isBranding))
-      .map(_.map(item => InternalOnlineOutputMessage.toOnlineOutputMessage(item)))
+      .map(_.filterNot(isBranding).map(InternalOnlineOutputMessage.toOnlineOutputMessage))
   }
 
   def enhanceOnlineResultsWithCrosslinkStatus(items: Seq[OnlineOutputMessage]): Future[Seq[(SendRemoveActionTarget.Value, OnlineOutputMessage)]] =
@@ -98,7 +97,7 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig, asLookup: AssetFol
     )
     ).filterNot(isBranding)
       // .filterNot(isMetadataOrProxy) // TODO Figure out if we should filter these out or not, given that they DO work for files that do not need to be on Deep Archive to be deletable
-      .map(entry => InternalOnlineOutputMessage.toOnlineOutputMessage(entry))
+      .map(InternalOnlineOutputMessage.toOnlineOutputMessage)
       .toMat(sinkFactory)(Keep.right)
       .run()
   }

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -554,56 +554,56 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       result.size mustEqual 4
     }
 
-    "searchAssociatedOnlineMedia3" in {
-
-      val asLookup = new AssetFolderLookup(fakePlutoConfig)
-      val mockAsLookup = mock[AssetFolderLookup]
-
-      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
-
-      val onlineResults = Seq(
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath1"), fileSize = Some(1024), itemId = Some(s"VX-1"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes", projectIds = Seq(8000, 10)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath2"), fileSize = Some(1024), itemId = Some(s"VX-2"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes", projectIds = Seq(8000, 20, 8000)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath4"), fileSize = Some(1024), itemId = Some(s"VX-4"), nearlineId = Some(s"mxsOid-44"), mediaCategory = "Rushes", projectIds = Seq(8000, 300, 310, 320)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-33"), mediaCategory = "Rushes", projectIds = Seq(8000, 8000)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-34"), mediaCategory = "Branding", projectIds = Seq(9000)),
-      )
-
-
-      implicit val mockVidispineCommunicator = mock[VidispineCommunicator]
-      mockVidispineCommunicator.getFilesOfProject(any, any) returns Future(onlineResults)
-
-      mockAsLookup.getProjectMetadata("10") returns Future(Some(projectWithStatus(EntryStatus.New)))
-      mockAsLookup.getProjectMetadata("11") returns Future(Some(projectWithStatus(EntryStatus.New)))
-      mockAsLookup.getProjectMetadata("12") returns Future(Some(projectWithStatus(EntryStatus.New)))
-      mockAsLookup.getProjectMetadata("20") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
-      mockAsLookup.getProjectMetadata("21") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
-      mockAsLookup.getProjectMetadata("22") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
-      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Held)))
-      mockAsLookup.getProjectMetadata("310") returns Future(Some(projectWithStatus(EntryStatus.Held)))
-      mockAsLookup.getProjectMetadata("320") returns Future(Some(projectWithStatus(EntryStatus.Held)))
-      mockAsLookup.getProjectMetadata("8000") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
-      mockAsLookup.getProjectMetadata("8100") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
-      mockAsLookup.getProjectMetadata("8200") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
-      mockAsLookup.getProjectMetadata("9000") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
-      mockAsLookup.getProjectMetadata("9100") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
-      mockAsLookup.getProjectMetadata("9200") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
-      mockAsLookup.getProjectMetadata("1") returns Future(None)
-      mockAsLookup.getProjectMetadata("2") returns Future(None)
-      mockAsLookup.getProjectMetadata("3") returns Future(None)
-
-
-      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
-
-      mockAsLookup.assetFolderProjectLookup(any) returns Future(Some(ProjectRecord(None, 1, "test", ZonedDateTime.now(), ZonedDateTime.now(), "test", None, None, None, None, None, EntryStatus.InProduction, ProductionOffice.UK)))
-      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Completed.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
-
-      val result = Await.result(toTest.searchAssociatedOnlineMedia3(mockVidispineCommunicator, 1), 2.seconds)
-
-      result.foreach(r => println(s"${r._1}, ${r._2.vidispineItemId}."))
-      println(s"onlineFilesByProject3 $result")
-      result.size mustEqual 2
-    }
+//    "searchAssociatedOnlineMedia3" in {
+//
+//      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+//      val mockAsLookup = mock[AssetFolderLookup]
+//
+//      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+//
+//      val onlineResults = Seq(
+//        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath1"), fileSize = Some(1024), itemId = Some(s"VX-1"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes", projectIds = Seq(8000, 10)),
+//        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath2"), fileSize = Some(1024), itemId = Some(s"VX-2"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes", projectIds = Seq(8000, 20, 8000)),
+//        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath4"), fileSize = Some(1024), itemId = Some(s"VX-4"), nearlineId = Some(s"mxsOid-44"), mediaCategory = "Rushes", projectIds = Seq(8000, 300, 310, 320)),
+//        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-33"), mediaCategory = "Rushes", projectIds = Seq(8000, 8000)),
+//        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-34"), mediaCategory = "Branding", projectIds = Seq(9000)),
+//      )
+//
+//
+//      implicit val mockVidispineCommunicator = mock[VidispineCommunicator]
+//      mockVidispineCommunicator.getFilesOfProject(any, any) returns Future(onlineResults)
+//
+//      mockAsLookup.getProjectMetadata("10") returns Future(Some(projectWithStatus(EntryStatus.New)))
+//      mockAsLookup.getProjectMetadata("11") returns Future(Some(projectWithStatus(EntryStatus.New)))
+//      mockAsLookup.getProjectMetadata("12") returns Future(Some(projectWithStatus(EntryStatus.New)))
+//      mockAsLookup.getProjectMetadata("20") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+//      mockAsLookup.getProjectMetadata("21") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+//      mockAsLookup.getProjectMetadata("22") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+//      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+//      mockAsLookup.getProjectMetadata("310") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+//      mockAsLookup.getProjectMetadata("320") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+//      mockAsLookup.getProjectMetadata("8000") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+//      mockAsLookup.getProjectMetadata("8100") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+//      mockAsLookup.getProjectMetadata("8200") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+//      mockAsLookup.getProjectMetadata("9000") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+//      mockAsLookup.getProjectMetadata("9100") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+//      mockAsLookup.getProjectMetadata("9200") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+//      mockAsLookup.getProjectMetadata("1") returns Future(None)
+//      mockAsLookup.getProjectMetadata("2") returns Future(None)
+//      mockAsLookup.getProjectMetadata("3") returns Future(None)
+//
+//
+//      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+//
+//      mockAsLookup.assetFolderProjectLookup(any) returns Future(Some(ProjectRecord(None, 1, "test", ZonedDateTime.now(), ZonedDateTime.now(), "test", None, None, None, None, None, EntryStatus.InProduction, ProductionOffice.UK)))
+//      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Completed.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
+//
+//      val result = Await.result(toTest.searchAssociatedOnlineMedia3(mockVidispineCommunicator, 1), 2.seconds)
+//
+//      result.foreach(r => println(s"${r._1}, ${r._2.vidispineItemId}."))
+//      println(s"onlineFilesByProject3 $result")
+//      result.size mustEqual 2
+//    }
     "handleUpdateMessage3" in {
 
       val asLookup = new AssetFolderLookup(fakePlutoConfig)
@@ -612,17 +612,20 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 //      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
 
       val nearlineResults = Seq(
-        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-44", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath4").withValue("GNM_PROJECT_ID", "44").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
-        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-10", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath0").withValue("GNM_PROJECT_ID", "10").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
-        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-11", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath1").withValue("GNM_PROJECT_ID", "11").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-10", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath10").withValue("GNM_PROJECT_ID", "8100").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-11", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath11").withValue("GNM_PROJECT_ID", "8000").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-440", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath44").withValue("GNM_PROJECT_ID", "8000").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-4500", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath45").withValue("GNM_PROJECT_ID", "9000").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
       )
 
       val onlineResults = Seq(
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath1"), fileSize = Some(1024), itemId = Some(s"VX-1"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes", projectIds = Seq(8000, 10)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath2"), fileSize = Some(1024), itemId = Some(s"VX-2"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes", projectIds = Seq(8000, 20, 8000)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath4"), fileSize = Some(1024), itemId = Some(s"VX-4"), nearlineId = Some(s"mxsOid-44"), mediaCategory = "Rushes", projectIds = Seq(8000, 300, 310, 320)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-33"), mediaCategory = "Rushes", projectIds = Seq(8000, 8000)),
-        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-34"), mediaCategory = "Branding", projectIds = Seq(9000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath11"), fileSize = Some(1024), itemId = Some(s"VX-11"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes", projectIds = Seq(8000, 11)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath22"), fileSize = Some(1024), itemId = Some(s"VX-22"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes", projectIds = Seq(8000, 20, 8000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath23"), fileSize = Some(1024), itemId = Some(s"VX-23"), nearlineId = Some(s"mxsOid-23"), mediaCategory = "Rushes", projectIds = Seq(23)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath44"), fileSize = Some(1024), itemId = Some(s"VX-440"), nearlineId = Some(s"mxsOid-440"), mediaCategory = "Rushes", projectIds = Seq(8000, 300, 310, 320)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath33"), fileSize = Some(1024), itemId = Some(s"VX-3300"), nearlineId = Some(s"mxsOid-3300"), mediaCategory = "Rushes", projectIds = Seq(8000, 8000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath45"), fileSize = Some(1024), itemId = Some(s"VX-4500"), nearlineId = Some(s"mxsOid-4500"), mediaCategory = "Rushes", projectIds = Seq(9000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath46"), fileSize = Some(1024), itemId = Some(s"VX-4501"), nearlineId = Some(s"mxsOid-4501"), mediaCategory = "Branding", projectIds = Seq(9000)),
       )
 
 

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -1,4 +1,5 @@
 
+import PlutoCoreMessageProcessor.SendRemoveAction
 import akka.actor.ActorSystem
 import akka.stream.Materializer
 import com.gu.multimedia.mxscopy.models.{MxsMetadata, ObjectMatrixEntry}
@@ -198,7 +199,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "return false if no GNM_TYPE" in {
 
-      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
 
       val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty), None))
 
@@ -207,7 +208,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "return true if GNM_TYPE is exactly 'Proxy'" in {
 
-      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
 
       val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Proxy")), None))
 
@@ -216,7 +217,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "return true if GNM_TYPE is exactly 'proxy'" in {
 
-      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
       val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "proxy")), None))
 
       result must beTrue
@@ -224,7 +225,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "return true if GNM_TYPE is exactly 'metadata'" in {
 
-      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
       val result = toTest.isMetadataOrProxy(ObjectMatrixEntry("oid", Some(MxsMetadata.empty.withValue("GNM_TYPE", "metadata")), None))
 
       result must beTrue
@@ -232,7 +233,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "filter out the 'metadata' and 'proxy' items" in {
 
-      val toTest = new PlutoCoreMessageProcessor(mxsConfig)
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
       val entries = Seq(
         ObjectMatrixEntry("oid1", Some(MxsMetadata.empty.withValue("GNM_TYPE", "Branding")), None),
         ObjectMatrixEntry("oid2", Some(MxsMetadata.empty.withValue("GNM_TYPE", "rushes")), None),
@@ -485,7 +486,13 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
     }
   }
 
-  "PlutoCoreMessageProcessor.isDeletableInAllProjects(VSOnlineOutputMessage)" should {
+  "PlutoCoreMessageProcessor.onlineFilesByProject3" should {
+
+    implicit val mockActorSystem = mock[ActorSystem]
+    val vault = mock[Vault]
+    implicit val mockMat = mock[Materializer]
+    implicit val mockBuilder = MXSConnectionBuilderMock(vault)
+    implicit val mockVidispineCommunicator = mock[VidispineCommunicator]
 
     def projectWithStatus(status: EntryStatus.Value) = {
       ProjectRecord(
@@ -504,39 +511,492 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
         productionOffice = ProductionOffice.UK)
     }
 
-    "return false if InProduction" in {
 
-      mockAsLookup.getProjectMetadata("123") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
-      mockAsLookup.getProjectMetadata("124") returns Future(Some(projectWithStatus(EntryStatus.Held)))
-      mockAsLookup.getProjectMetadata("125") returns Future(Some(projectWithStatus(EntryStatus.New)))
-      mockAsLookup.getProjectMetadata("126") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
-      mockAsLookup.getProjectMetadata("127") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
-      mockAsLookup.getProjectMetadata("128") returns Future(None)
+    "onlineFilesByProject3" in {
+
+      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+      val mockAsLookup = mock[AssetFolderLookup]
+
+      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+
+      val onlineResults = Seq(
+        VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(100), filePath = Some(s"filePath1"), fileSize = Some(1024), itemId = Some(s"VX-1"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes"),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(200), filePath = Some(s"filePath2"), fileSize = Some(1024), itemId = Some(s"VX-2"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes"),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(250), filePath = Some(s"filePath4"), fileSize = Some(1024), itemId = Some(s"VX-4"), nearlineId = Some(s"mxsOid-44"), mediaCategory = "Rushes"),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(300), filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-33"), mediaCategory = "Rushes"),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(301), filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-34"), mediaCategory = "Branding"),
+      )
+
+
+      implicit val mockVidispineCommunicator = mock[VidispineCommunicator]
+      mockVidispineCommunicator.getFilesOfProject(any, any) returns Future(onlineResults)
+
+      mockAsLookup.getProjectMetadata("100") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("200") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("250") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("999") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+//        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
+//        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(onlineResults)
+      }
+
+      mockAsLookup.assetFolderProjectLookup(any) returns Future(Some(ProjectRecord(None, 1, "test", ZonedDateTime.now(), ZonedDateTime.now(), "test", None, None, None, None, None, EntryStatus.InProduction, ProductionOffice.UK)))
+      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Completed.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
+
+      val result = Await.result(toTest.onlineFilesByProject3(mockVidispineCommunicator, 1), 2.seconds)
+
+      result.foreach(r => println(s"${r._1}, ${r._2.vidispineItemId.get}"))
+      println(s"onlineFilesByProject3 $result")
+      result.size mustEqual 4
+    }
+
+    "searchAssociatedOnlineMedia3" in {
+
+      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+      val mockAsLookup = mock[AssetFolderLookup]
+
+      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+
+      val onlineResults = Seq(
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath1"), fileSize = Some(1024), itemId = Some(s"VX-1"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes", projectIds = Seq(8000, 10)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath2"), fileSize = Some(1024), itemId = Some(s"VX-2"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes", projectIds = Seq(8000, 20, 8000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath4"), fileSize = Some(1024), itemId = Some(s"VX-4"), nearlineId = Some(s"mxsOid-44"), mediaCategory = "Rushes", projectIds = Seq(8000, 300, 310, 320)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-33"), mediaCategory = "Rushes", projectIds = Seq(8000, 8000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-34"), mediaCategory = "Branding", projectIds = Seq(9000)),
+      )
+
+
+      implicit val mockVidispineCommunicator = mock[VidispineCommunicator]
+      mockVidispineCommunicator.getFilesOfProject(any, any) returns Future(onlineResults)
+
+      mockAsLookup.getProjectMetadata("10") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("11") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("12") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("20") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("21") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("22") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("310") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("320") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("8000") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("8100") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("8200") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("9000") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("9100") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("9200") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+      mockAsLookup.getProjectMetadata("2") returns Future(None)
+      mockAsLookup.getProjectMetadata("3") returns Future(None)
+
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
-      val item = VSOnlineOutputMessage("ONLINE", Seq(123, 124, 125, 126, 127, 128), Some("a/path/123"), Some(1L), Some("VX-1"), Some("oid1"), "branding")
-      val result = toTest.isDeletableInAllProjectsFut(item)
 
-      result must beFalse
+      mockAsLookup.assetFolderProjectLookup(any) returns Future(Some(ProjectRecord(None, 1, "test", ZonedDateTime.now(), ZonedDateTime.now(), "test", None, None, None, None, None, EntryStatus.InProduction, ProductionOffice.UK)))
+      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Completed.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
+
+      val result = Await.result(toTest.searchAssociatedOnlineMedia3(mockVidispineCommunicator, 1), 2.seconds)
+
+      result.foreach(r => println(s"${r._1}, ${r._2.vidispineItemId}."))
+      println(s"onlineFilesByProject3 $result")
+      result.size mustEqual 2
+    }
+    "handleUpdateMessage3" in {
+
+      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+      val mockAsLookup = mock[AssetFolderLookup]
+
+//      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+
+      val nearlineResults = Seq(
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-44", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath4").withValue("GNM_PROJECT_ID", "44").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-10", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath0").withValue("GNM_PROJECT_ID", "10").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+        InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid-11", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"filepath1").withValue("GNM_PROJECT_ID", "11").withValue("GNM_TYPE", "rushes")), fileAttribues = None)),
+      )
+
+      val onlineResults = Seq(
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath1"), fileSize = Some(1024), itemId = Some(s"VX-1"), nearlineId = Some(s"mxsOid-11"), mediaCategory = "Rushes", projectIds = Seq(8000, 10)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath2"), fileSize = Some(1024), itemId = Some(s"VX-2"), nearlineId = Some(s"mxsOid-22"), mediaCategory = "Rushes", projectIds = Seq(8000, 20, 8000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath4"), fileSize = Some(1024), itemId = Some(s"VX-4"), nearlineId = Some(s"mxsOid-44"), mediaCategory = "Rushes", projectIds = Seq(8000, 300, 310, 320)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-33"), mediaCategory = "Rushes", projectIds = Seq(8000, 8000)),
+        VSOnlineOutputMessage(mediaTier = "ONLINE", filePath = Some(s"filePath3"), fileSize = Some(1024), itemId = Some(s"VX-3"), nearlineId = Some(s"mxsOid-34"), mediaCategory = "Branding", projectIds = Seq(9000)),
+      )
+
+
+      implicit val mockVidispineCommunicator = mock[VidispineCommunicator]
+      mockVidispineCommunicator.getFilesOfProject(any, any) returns Future(onlineResults)
+
+      mockAsLookup.getProjectMetadata("10") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("11") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("12") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("20") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("21") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("22") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("310") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("320") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("8000") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("8100") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("8200") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("9000") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("9100") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("9200") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+      mockAsLookup.getProjectMetadata("2") returns Future(None)
+      mockAsLookup.getProjectMetadata("3") returns Future(None)
+
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
+      }
+
+      mockAsLookup.assetFolderProjectLookup(any) returns Future(Some(ProjectRecord(None, 1, "test", ZonedDateTime.now(), ZonedDateTime.now(), "test", None, None, None, None, None, EntryStatus.InProduction, ProductionOffice.UK)))
+
+      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Held.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
+
+      val result = Await.result(toTest.handleUpdateMessage3(updateMessage, framework), 2.seconds)
+
+
+      println(s"handleUpdateMessage3 $result")
+      ok
+    }
+
+    "return message with correct amount of associated files if status is Held" in {
+      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+      val onlineResults = for (i <- 1 to 3) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
+        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(onlineResults)
+      }
+
+      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Held.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
+
+      val result = Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)
+
+      result must beRight
+      val resData = result.map(_.content).getOrElse("".asJson).as[RestorerSummaryMessage]
+      resData must beRight
+      val summaryMessage = resData.right.get
+      summaryMessage.projectId mustEqual 233
+      summaryMessage.completed must beLessThanOrEqualTo(ZonedDateTime.now())
+      summaryMessage.projectState mustEqual "Held"
+      summaryMessage.numberOfAssociatedFilesNearline mustEqual 2
+      summaryMessage.numberOfAssociatedFilesOnline mustEqual 3
+    }
+
+    "return message with correct amount of associated files if status is Killed" in {
+      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+      val onlineResults = for (i <- 1 to 3) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
+        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(onlineResults)
+      }
+
+      val updateMessage = ProjectUpdateMessage(status = EntryStatus.Killed.toString, id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, productionOffice = "LDN")
+
+      val result = Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)
+
+      result must beRight
+      val resData = result.map(_.content).getOrElse("".asJson).as[RestorerSummaryMessage]
+      resData must beRight
+      val summaryMessage = resData.right.get
+      summaryMessage.projectId mustEqual 233
+      summaryMessage.completed must beLessThanOrEqualTo(ZonedDateTime.now())
+      summaryMessage.projectState mustEqual "Killed"
+      summaryMessage.numberOfAssociatedFilesNearline mustEqual 2
+      summaryMessage.numberOfAssociatedFilesOnline mustEqual 3
     }
 
 
-//    "filter out the branding/BRANDING/Branding/etc items" in {
-//
-//      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
-//      val items = Seq(
-//        VSOnlineOutputMessage("ONLINE", Seq(123), Some("a/path/1"), Some(1L), Some("VX-1"), Some("oid1"), "Branding"),
-//        VSOnlineOutputMessage("ONLINE", Seq(123), Some("a/path/2"), Some(1L), Some("VX-2"), Some("oid2"), "rushes"),
-//        VSOnlineOutputMessage("ONLINE", Seq(123), Some("a/path/3"), Some(1L), Some("VX-3"), Some("oid3"), "branding"),
-//        VSOnlineOutputMessage("ONLINE", Seq(123), Some("a/path/4"), Some(1L), Some("VX-4"), Some("oid4"), "Branding"),
-//        VSOnlineOutputMessage("ONLINE", Seq(123), Some("a/path/5"), Some(1L), Some("VX-5"), Some("oid5"), "project"),
-//      )
-//
-//      val result = items.filterNot(toTest.isBranding)
-//
-//      result.size mustEqual 2
-//      result.head.itemId must beSome("VX-2")
-//    }
+    "fail if project has too many associated online files" in {
+      val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
+      val tooManyOnlineResults = for (i <- 1 to 10001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
+        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(tooManyOnlineResults)
+      }
+
+      val updateMessage = ProjectUpdateMessage(id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, status = EntryStatus.Completed.toString, productionOffice = "LDN")
+      val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 3.seconds)}
+      result must beFailedTry
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 2, onlineResults = 10001"
+    }
+
+
+    "fail if project has too many associated nearline files" in {
+      val tooManyNearlineResults = for(i <- 1 to 10001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val onlineResults = for (i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(tooManyNearlineResults)
+        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(onlineResults)
+      }
+
+      val updateMessage = ProjectUpdateMessage(id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, status = EntryStatus.Completed.toString, productionOffice = "LDN")
+
+      val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)}
+
+      result must beFailedTry
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 10001, onlineResults = 2"
+    }
+
+
+    "fail if project has too many associated nearline and online files" in {
+      val tooManyNearlineResults = for(i <- 1 to 10001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyOnlineResults = for (i <- 1 to 10002) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(tooManyNearlineResults)
+        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(tooManyOnlineResults)
+      }
+
+      val updateMessage = ProjectUpdateMessage(id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, status = EntryStatus.Completed.toString, productionOffice = "LDN")
+
+      val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)}
+
+      result must beFailedTry
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 10001, onlineResults = 10002"
+    }
+
+
+    "retry if vault could not be acquired" in {
+      val onlineResults = for (i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
+        override def getNearlineResults(projectId: Int) = Future(Left("No vault for you!"))
+        override def onlineFilesByProject(vidispineCommunicator: VidispineCommunicator, projectId: Int): Future[Seq[OnlineOutputMessage]] = Future(onlineResults)
+      }
+
+      val updateMessage = ProjectUpdateMessage(id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, status = EntryStatus.Completed.toString, productionOffice = "LDN")
+
+      val result =  Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)
+
+      result must beLeft
+      result.left.get mustEqual "No vault for you!"
+    }
+  }
+
+  "PlutoCoreMessageProcessor.isDeletableInAllProjects(VSOnlineOutputMessage)" should {
+
+    val asLookup = new AssetFolderLookup(fakePlutoConfig)
+    val mockAsLookup = mock[AssetFolderLookup]
+
+    def projectWithStatus(status: EntryStatus.Value) = {
+      ProjectRecord(
+        id = None,
+        projectTypeId = 1,
+        title = "test",
+        created = ZonedDateTime.now(),
+        updated = ZonedDateTime.now(),
+        user = "test",
+        workingGroupId = None,
+        commissionId = None,
+        deletable = None,
+        deep_archive = None,
+        sensitive = None,
+        status = status,
+        productionOffice = ProductionOffice.UK)
+    }
+
+    "return 'still in use' if InProduction" in {
+      mockAsLookup.getProjectMetadata("100") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("200") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("250") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("999") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val item = InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage("ONLINE", Seq(200, 250, 100, 999, 300, 1), Some("a/path/123"), Some(1L), Some("VX-1"), Some("oid1"), "Rushes"))
+      val result = Await.result(toTest.isDeletableInAllProjectsFut(item), 2.seconds)
+
+      result mustEqual SendRemoveAction.No
+    }
+
+    "return 'held' if only Held and None" in {
+      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+      val mockAsLookup = mock[AssetFolderLookup]
+
+      mockAsLookup.getProjectMetadata("100") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("200") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("251") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("999") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("2") returns Future(None)
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val item = InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage("ONLINE", Seq(251, 2), Some("a/path/123"), Some(1L), Some("VX-1"), Some("oid1"), "Rushes"))
+      val result = Await.result(toTest.isDeletableInAllProjectsFut(item), 2.seconds)
+
+      result mustEqual SendRemoveAction.OnlyOnline
+    }
+
+    "return 'free to remove' if only Completed and Killed" in {
+      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+      val mockAsLookup = mock[AssetFolderLookup]
+
+      mockAsLookup.getProjectMetadata("100") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("200") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("250") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("301") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("998") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val item = InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage("ONLINE", Seq(301, 998), Some("a/path/123"), Some(1L), Some("VX-1"), Some("oid1"), "Rushes"))
+      val result = Await.result(toTest.isDeletableInAllProjectsFut(item), 2.seconds)
+
+      result mustEqual SendRemoveAction.Yes
+    }
+
+    "return 'free to remove' if only None" in {
+      val asLookup = new AssetFolderLookup(fakePlutoConfig)
+      val mockAsLookup = mock[AssetFolderLookup]
+      mockAsLookup.getProjectMetadata("100") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("200") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("250") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("999") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val item = InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage("ONLINE", Seq(1), Some("a/path/123"), Some(1L), Some("VX-1"), Some("oid1"), "Rushes"))
+      val result = Await.result(toTest.isDeletableInAllProjectsFut(item), 2.seconds)
+
+      result mustEqual SendRemoveAction.Yes
+    }
+
+    "return 'free to remove' if empty" in {
+      mockAsLookup.getProjectMetadata("100") returns Future(Some(projectWithStatus(EntryStatus.New)))
+      mockAsLookup.getProjectMetadata("200") returns Future(Some(projectWithStatus(EntryStatus.InProduction)))
+      mockAsLookup.getProjectMetadata("250") returns Future(Some(projectWithStatus(EntryStatus.Held)))
+      mockAsLookup.getProjectMetadata("300") returns Future(Some(projectWithStatus(EntryStatus.Completed)))
+      mockAsLookup.getProjectMetadata("999") returns Future(Some(projectWithStatus(EntryStatus.Killed)))
+      mockAsLookup.getProjectMetadata("1") returns Future(None)
+
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val item = InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage("ONLINE", Seq(), Some("a/path/123"), Some(1L), Some("VX-1"), Some("oid1"), "Rushes"))
+      val result = Await.result(toTest.isDeletableInAllProjectsFut(item), 2.seconds)
+
+      result mustEqual SendRemoveAction.Yes
+    }
+  }
+
+  "PlutoCoreMessageProcessor.stillInUse" should {
+    val HELD = Some(EntryStatus.Held)
+    val NEW = Some(EntryStatus.New)
+    val COMPLETED = Some(EntryStatus.Completed)
+    val KILLED = Some(EntryStatus.Killed)
+    val IN_PRODUCTION = Some(EntryStatus.InProduction)
+
+    "return true if any New or InProduction" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.stillInUse(Seq(HELD, NEW))
+      result must beTrue
+    }
+
+    "return false if no New or InProduction" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.stillInUse(Seq(HELD, KILLED, COMPLETED, HELD))
+      result must beFalse
+    }
+
+    "return false if Held and None" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.stillInUse(Seq(HELD, None, HELD))
+      result must beFalse
+    }
+
+    "return true if only New or InProduction" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.stillInUse(Seq(NEW, IN_PRODUCTION, NEW, IN_PRODUCTION))
+      result must beTrue
+    }
+
+    "return false if no statuses" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.stillInUse(Seq(None, None))
+      result must beFalse
+    }
+
+  }
+
+  "PlutoCoreMessageProcessor.lowestIsHeld" should {
+    val HELD = Some(EntryStatus.Held)
+    val NEW = Some(EntryStatus.New)
+    val COMPLETED = Some(EntryStatus.Completed)
+    val KILLED = Some(EntryStatus.Killed)
+    val IN_PRODUCTION = Some(EntryStatus.InProduction)
+
+    "return true if Held for all" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.lowestIsHeld(Seq(HELD, HELD, HELD))
+      result must beTrue
+    }
+
+    "return false if Held and Completed and Killed" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.lowestIsHeld(Seq(HELD, KILLED, COMPLETED, HELD))
+      result must beFalse
+    }
+
+    "return false if Held and New and InProduction" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.lowestIsHeld(Seq(NEW, IN_PRODUCTION, HELD, IN_PRODUCTION))
+      result must beFalse
+    }
+
+    "return false if no statuses" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.lowestIsHeld(Seq(None, None))
+      result must beFalse
+    }
+
+  }
+
+  "PlutoCoreMessageProcessor.releasedByAll" should {
+    val HELD = Some(EntryStatus.Held)
+    val NEW = Some(EntryStatus.New)
+    val COMPLETED = Some(EntryStatus.Completed)
+    val KILLED = Some(EntryStatus.Killed)
+    val IN_PRODUCTION = Some(EntryStatus.InProduction)
+
+    "return false if Held for all" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.releasedByAll(Seq(HELD, HELD, HELD))
+      result must beFalse
+    }
+
+    "return false if Held and Completed and Killed" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.releasedByAll(Seq(HELD, KILLED, COMPLETED, HELD))
+      result must beFalse
+    }
+
+    "return true if Completed and Killed" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.releasedByAll(Seq(KILLED, COMPLETED, KILLED))
+      result must beTrue
+    }
+
+    "return true if no statuses" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.releasedByAll(Seq(None, None))
+      result must beTrue
+    }
+
+    "return false if Held and New and InProduction" in {
+      val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup)
+      val result = toTest.releasedByAll(Seq(NEW, IN_PRODUCTION, HELD, IN_PRODUCTION))
+      result must beFalse
+    }
+
   }
 
 }


### PR DESCRIPTION
## What does this change?

Check crosslinked media, via the online items, so that we do not delete media still in use by some other project than the one that triggered the `project_restorer`.

- Get the online items
  - Get the nearline items
    - Get the status for each containing project except the one that triggered the whole she-bang, for each online item
    - If the highest level is `Held`, allow sending of `media_not_required.online`
    - If the highest level is `Killed` or `Completed`, allow sending of media_not_required.online and `media_not_required.nearline`
    - If the highest level is `New` or `InProduction,` do not allow either `media_not_required` message to
  be sent
    - Filter out these media items from the outgoing messages by `vidispineItemId` and `nearlineId` respectively.

## Why is the change needed?

We do not want to delete media from nearline unless is `Completed` or `Killed` for all projects, and for online, `Held` is OK to delete as well. Thus we need to check the project statuses of all containing projects.

## Important implementation details

Note that we will only be able to filter out nearline messages for those online items that have a `nearlineId` set.

## Risks to consider when deploying

<!-- does this touch live data? Are there database migrations that would complicate a roll-back? Is it just generally scary? -->
