### PR TITLE
Fix readout/swapped fields in decodeAssetSweeperNewFile

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/messages/AssetSweeperNewFile.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/messages/AssetSweeperNewFile.scala
@@ -49,8 +49,8 @@ object AssetSweeperNewFile {
           aTime <- c.downField("atime").as[Double]
           owner <- c.downField("owner").as[Int]
           group <- c.downField("group").as[Int]
-          filename <- c.downField("parent_dir").as[String]
-          parentDir <- c.downField("filename").as[String]
+          parentDir <- c.downField("parent_dir").as[String]
+          filename <- c.downField("filename").as[String]
         } yield AssetSweeperNewFile(
           importedId,
           size,
@@ -61,8 +61,8 @@ object AssetSweeperNewFile {
           ZonedDateTime.ofInstant(Instant.ofEpochMilli((aTime*1000.0).toLong), ZoneId.of("Etc/UTC")),
           owner,
           group,
-          filename,
-          parentDir
+          parentDir,
+          filename
         )
       }
     }


### PR DESCRIPTION
## What does this change?
Decreases the mental load to understand `decodeAssetSweeperNewFile` by removing two small errors that cancelled each other out. 

No functional changes.

## Why is the change needed?
Sometimes two wrongs _does_ make a right, but zero wrongs is even better.
The previous, wrong, readout worked, because the argument order for `filename` and `parentDir` in the `AssetSweeperNewFile()` call was also swapped.
<!-- Prefer to copy-paste as not everyone may have access to Jira or Trello. References are ok in addition but please include enough context. -->

## Important implementation details

<!-- e.g. some novel algorithm, or explaining iteraction between multiple components -->

## Risks to consider when deploying

<!-- does this touch live data? Are there database migrations that would complicate a roll-back? Is it just generally scary? -->
