### PR TITLE
Rp/handle empty list

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
@@ -57,7 +57,7 @@ object VSOnlineOutputMessage {
   ): Option[VSOnlineOutputMessage] = {
     val mediaTier = "ONLINE"
     val itemId = Option(itemSimplified.id)
-    val likelyFile = itemSimplified.item.shape.head.getLikelyFile
+    val likelyFile = itemSimplified.item.shape.headOption.flatMap(_.getLikelyFile)
     val filePath = likelyFile.flatMap(_.getAbsolutePath)
     val fileSize = likelyFile.flatMap(_.sizeOption)
     val projectIdAndContainingProjectIds = projectId +: safeGetContainingProjects(itemSimplified)

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
@@ -55,9 +55,13 @@ object VSOnlineOutputMessage {
       itemSimplified: SearchResultItemSimplified,
       projectId: Int
   ): Option[VSOnlineOutputMessage] = {
+    logger.info(s"itemSimplified: $itemSimplified")
+    logger.info(s"itemSimplified.item: ${itemSimplified.item}")
+
     val mediaTier = "ONLINE"
     val itemId = Option(itemSimplified.id)
     val likelyFile = itemSimplified.item.shape.headOption.flatMap(_.getLikelyFile)
+    logger.info(s"likelyFile: $likelyFile")
     val filePath = likelyFile.flatMap(_.getAbsolutePath)
     val fileSize = likelyFile.flatMap(_.sizeOption)
     val projectIdAndContainingProjectIds = projectId +: safeGetContainingProjects(itemSimplified)

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/SearchResultDocument.scala
@@ -55,13 +55,10 @@ object VSOnlineOutputMessage {
       itemSimplified: SearchResultItemSimplified,
       projectId: Int
   ): Option[VSOnlineOutputMessage] = {
-    logger.info(s"itemSimplified: $itemSimplified")
-    logger.info(s"itemSimplified.item: ${itemSimplified.item}")
-
     val mediaTier = "ONLINE"
     val itemId = Option(itemSimplified.id)
     val likelyFile = itemSimplified.item.shape.headOption.flatMap(_.getLikelyFile)
-    logger.info(s"likelyFile: $likelyFile")
+    logger.debug(s"likelyFile: $likelyFile")
     val filePath = likelyFile.flatMap(_.getAbsolutePath)
     val fileSize = likelyFile.flatMap(_.sizeOption)
     val projectIdAndContainingProjectIds = projectId +: safeGetContainingProjects(itemSimplified)

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
@@ -50,11 +50,11 @@ case class ShapeDocument(
     val allComponentFiles = containerComponent match {
       case Some(container) =>
         val  files = container.file ++ audioFiles ++ videoFiles ++ binaryFiles
-        logger.info(s"allComponentFiles with container: $files")
+        logger.debug(s"allComponentFiles with container: $files")
         files
       case None =>
         val files = audioFiles ++ videoFiles ++ binaryFiles
-        logger.info(s"allComponentFiles without container: $files")
+        logger.debug(s"allComponentFiles without container: $files")
         files
     }
     val fileIdMap = allComponentFiles.foldLeft(Map[String, VSShapeFile]())((acc, elem)=>acc + (elem.id->elem))

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/ShapeDocument.scala
@@ -48,8 +48,14 @@ case class ShapeDocument(
     val binaryFiles = binaryComponent.getOrElse(Seq.empty[SimplifiedComponent]).flatMap(_.file)
 
     val allComponentFiles = containerComponent match {
-      case Some(container) => container.file ++ audioFiles ++ videoFiles ++ binaryFiles
-      case None => audioFiles ++ videoFiles ++ binaryFiles
+      case Some(container) =>
+        val  files = container.file ++ audioFiles ++ videoFiles ++ binaryFiles
+        logger.info(s"allComponentFiles with container: $files")
+        files
+      case None =>
+        val files = audioFiles ++ videoFiles ++ binaryFiles
+        logger.info(s"allComponentFiles without container: $files")
+        files
     }
     val fileIdMap = allComponentFiles.foldLeft(Map[String, VSShapeFile]())((acc, elem)=>acc + (elem.id->elem))
     if(fileIdMap.size>1) {

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
@@ -256,7 +256,6 @@ class VidispineCommunicator(config:VidispineConfig) (implicit ec:ExecutionContex
 
 
   def recursivelyGetFilesOfProject(projectId: Int, start: Int = 1, pageSize: Int = 100, existingResults: Seq[Option[VSOnlineOutputMessage]] = Seq()): Future[Seq[Option[VSOnlineOutputMessage]]] = {
-//    val pageSize: Int = Math.min(100, pageSize) // Vidispine has a limit of 100 items per page
     getPageOfFilesOfProject(projectId, start, pageSize).flatMap(results => {
       if (results.isEmpty || start > maxFilesToFetch) {
         if (start > maxFilesToFetch) logger.warn(s"Exiting early from getting online files, because we have found more than maxFilesToFetch: $maxFilesToFetch, namely ${existingResults.length + results.length} files")

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
@@ -255,6 +255,7 @@ class VidispineCommunicator(config:VidispineConfig) (implicit ec:ExecutionContex
 
 
   def recursivelyGetFilesOfProject(projectId: Int, start: Int = 1, pageSize: Int = 100, existingResults: Seq[Option[VSOnlineOutputMessage]] = Seq()): Future[Seq[Option[VSOnlineOutputMessage]]] = {
+    val pageSize = Math.min(100, pageSize) // Vidispine has a limit of 100 items per page
     getPageOfFilesOfProject(projectId, start, pageSize).flatMap(results => {
       if (results.isEmpty || start > maxFilesToFetch) {
         if (start > maxFilesToFetch) logger.warn(s"Exiting early from getting online files, because we have found more than maxFilesToFetch: $maxFilesToFetch, namely ${existingResults.length + results.length} files")

--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
@@ -11,11 +11,10 @@ import com.gu.multimedia.storagetier.utils.AkkaHttpHelpers
 import com.gu.multimedia.storagetier.utils.AkkaHttpHelpers.{RedirectRequired, RetryRequired, consumeStream, contentBodyToJson}
 import io.circe.generic.auto._
 import org.slf4j.{LoggerFactory, MDC}
-import shapeless.Lazy.apply
 
 import java.net.URLEncoder
 import scala.concurrent.duration._
-import scala.concurrent.{Await, ExecutionContext, Future}
+import scala.concurrent.{ExecutionContext, Future}
 
 
 class VidispineCommunicator(config:VidispineConfig) (implicit ec:ExecutionContext, mat:Materializer, actorSystem:ActorSystem){

--- a/project_restorer/src/main/resources/application.conf
+++ b/project_restorer/src/main/resources/application.conf
@@ -1,3 +1,4 @@
 akka.http.host-connection-pool {
-  max-open-requests = 64
+  max-connections = 256
+  max-open-requests = 256 // Must be a power of 2
 }

--- a/project_restorer/src/main/resources/application.conf
+++ b/project_restorer/src/main/resources/application.conf
@@ -1,0 +1,3 @@
+akka.http.host-connection-pool {
+  max-open-requests = 64
+}

--- a/project_restorer/src/main/resources/application.conf
+++ b/project_restorer/src/main/resources/application.conf
@@ -1,4 +1,4 @@
 akka.http.host-connection-pool {
-  max-connections = 256
-  max-open-requests = 256 // Must be a power of 2
+  max-connections = 1024
+  max-open-requests = 1024 // Must be a power of 2
 }


### PR DESCRIPTION
Some requests to the Vidicore API were returning `None`. This change:
- refactors the `getPageOfFilesOfProject` method to handle Future results properly.
- adds debug logging