### PR TITLE
Cope with Projects With up to Thirty Thousand Items

### DIFF
--- a/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
+++ b/common/src/main/scala/com/gu/multimedia/storagetier/vidispine/VidispineCommunicator.scala
@@ -21,7 +21,7 @@ class VidispineCommunicator(config:VidispineConfig) (implicit ec:ExecutionContex
   private final val logger = LoggerFactory.getLogger(getClass)
 
   // maxFilesToFetch should have the same value as index.max_result_window in OpenSearch.
-  private final val maxFilesToFetch = 20000
+  private final val maxFilesToFetch = 30000
 
   protected def callHttp = Http()
 

--- a/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
+++ b/project_restorer/src/main/scala/PlutoCoreMessageProcessor.scala
@@ -170,7 +170,7 @@ class PlutoCoreMessageProcessor(mxsConfig: MatrixStoreConfig, asLookup: AssetFol
   private def processResults(allResults: Seq[Either[String, Seq[OnlineOutputMessage]]], routingKey: String, framework: MessageProcessingFramework, projectId: Int, projectStatus: String): Either[String, MessageProcessorReturnValue] =
     (allResults.head, allResults(1), allResults(2)) match {
       case (Right(onlineResults), Right(nearlineResults), Right(_)) =>
-        if (nearlineResults.length < 20000 && onlineResults.length < 20000) {
+        if (nearlineResults.length < 30000 && onlineResults.length < 30000) {
           logger.info(s"About to send bulk messages for ${nearlineResults.length} filtered nearline results")
           framework.bulkSendMessages(routingKey + ".nearline", nearlineResults)
 

--- a/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
+++ b/project_restorer/src/test/scala/PlutoCoreMessageProcessorSpec.scala
@@ -401,7 +401,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "fail if project has too many associated online files" in {
       val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
-      val tooManyOnlineResults = for (i <- 1 to 20001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyOnlineResults = for (i <- 1 to 30001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
         override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
@@ -411,12 +411,12 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       val updateMessage = ProjectUpdateMessage(id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, status = EntryStatus.Completed.toString, productionOffice = "LDN")
       val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 3.seconds)}
       result must beFailedTry
-      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 2, onlineResults = 20001"
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 2, onlineResults = 30001"
     }
 
 
     "fail if project has too many associated nearline files" in {
-      val tooManyNearlineResults = for(i <- 1 to 20001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyNearlineResults = for(i <- 1 to 30001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
       val onlineResults = for (i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
@@ -429,13 +429,13 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)}
 
       result must beFailedTry
-      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 20001, onlineResults = 2"
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 30001, onlineResults = 2"
     }
 
 
     "fail if project has too many associated nearline and online files" in {
-      val tooManyNearlineResults = for(i <- 1 to 20001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
-      val tooManyOnlineResults = for (i <- 1 to 20002) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyNearlineResults = for(i <- 1 to 30001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyOnlineResults = for (i <- 1 to 30002) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
         override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(tooManyNearlineResults)
@@ -447,7 +447,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)}
 
       result must beFailedTry
-      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 20001, onlineResults = 20002"
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 30001, onlineResults = 30002"
     }
 
 
@@ -664,7 +664,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
 
     "fail if project has too many associated online files" in {
       val nearlineResults = for(i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(ObjectMatrixEntry(oid = s"mxsOid$i", attributes = Some(MxsMetadata.empty.withValue("MXFS_PATH", s"mxfspath/$i").withValue("GNM_PROJECT_ID", "233").withValue("GNM_TYPE", "rushes")), fileAttribues = None))
-      val tooManyOnlineResults = for (i <- 1 to 20001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyOnlineResults = for (i <- 1 to 30001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
         override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(nearlineResults)
@@ -674,12 +674,12 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       val updateMessage = ProjectUpdateMessage(id = 233, projectTypeId = 2, title = "abcdefg", created = None, updated = None, user = "le user", workingGroupId = 100, commissionId = 200, deletable = true, deep_archive = false, sensitive = false, status = EntryStatus.Completed.toString, productionOffice = "LDN")
       val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 3.seconds)}
       result must beFailedTry
-      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 2, onlineResults = 20001"
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 2, onlineResults = 30001"
     }
 
 
     "fail if project has too many associated nearline files" in {
-      val tooManyNearlineResults = for(i <- 1 to 20001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyNearlineResults = for(i <- 1 to 30001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
       val onlineResults = for (i <- 1 to 2) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
@@ -692,13 +692,13 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)}
 
       result must beFailedTry
-      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 20001, onlineResults = 2"
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 30001, onlineResults = 2"
     }
 
 
     "fail if project has too many associated nearline and online files" in {
-      val tooManyNearlineResults = for(i <- 1 to 20001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
-      val tooManyOnlineResults = for (i <- 1 to 20002) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyNearlineResults = for(i <- 1 to 30001) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
+      val tooManyOnlineResults = for (i <- 1 to 30002) yield InternalOnlineOutputMessage.toOnlineOutputMessage(VSOnlineOutputMessage(mediaTier = "ONLINE", projectIds = Seq(233), filePath = Some(s"filePath$i"), fileSize = Some(1024), itemId = Some(s"VX-$i"), nearlineId = Some(s"mxsOid-${i+1}"), mediaCategory = "Branding"))
 
       val toTest = new PlutoCoreMessageProcessor(mxsConfig, mockAsLookup) {
         override def nearlineFilesByProject(vault: Vault, projectId: String): Future[Seq[OnlineOutputMessage]] = Future(tooManyNearlineResults)
@@ -710,7 +710,7 @@ class PlutoCoreMessageProcessorSpec(implicit ec: ExecutionContext) extends Speci
       val result = Try { Await.result(toTest.handleUpdateMessage(updateMessage, framework), 2.seconds)}
 
       result must beFailedTry
-      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 20001, onlineResults = 20002"
+      result.failed.get.getMessage mustEqual "Too many files attached to project 233, nearlineResults = 30001, onlineResults = 30002"
     }
 
 


### PR DESCRIPTION
## What does this change?

Adds support for projects with up to thirty thousand items.

## Why is the change needed?

So projects with more than twenty thousand items can be processed.

Tested on the dev. system.